### PR TITLE
Fixes #8 and #11: Add LoadingSpinner and 15-minute long break after 4 Pomodoro sessions

### DIFF
--- a/devboard/client/src/hooks/usePomodoro.js
+++ b/devboard/client/src/hooks/usePomodoro.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 
 const WORK_DURATION = 25 * 60; // 25 minutes
 const BREAK_DURATION = 5 * 60; // 5 minutes
+const LONG_BREAK_DURATION = 15 * 60; // 15 minutes
 
 export const usePomodoro = (onSessionComplete) => {
   const [timeLeft, setTimeLeft] = useState(WORK_DURATION);
@@ -18,11 +19,16 @@ export const usePomodoro = (onSessionComplete) => {
             clearInterval(intervalRef.current);
             setIsRunning(false);
             if (!isBreak) {
-              setSessionCount((s) => s + 1);
+              const nextCount = sessionCount + 1;
+              setSessionCount(nextCount);
               if (onSessionComplete) onSessionComplete();
+              setIsBreak(true);
+              const isLongBreak = nextCount % 4 === 0 && nextCount > 0;
+              return isLongBreak ? LONG_BREAK_DURATION : BREAK_DURATION;
+            } else {
+              setIsBreak(false);
+              return WORK_DURATION;
             }
-            setIsBreak((b) => !b);
-            return isBreak ? WORK_DURATION : BREAK_DURATION;
           }
           return prev - 1;
         });
@@ -31,13 +37,14 @@ export const usePomodoro = (onSessionComplete) => {
       clearInterval(intervalRef.current);
     }
     return () => clearInterval(intervalRef.current);
-  }, [isRunning, isBreak]);
+  }, [isRunning, isBreak, sessionCount, onSessionComplete]);
 
   const toggle = () => setIsRunning((r) => !r);
 
   const reset = () => {
     setIsRunning(false);
     setIsBreak(false);
+    setSessionCount(0);
     setTimeLeft(WORK_DURATION);
   };
 
@@ -47,8 +54,10 @@ export const usePomodoro = (onSessionComplete) => {
     return `${m}:${s}`;
   };
 
+  const currentBreakDuration = (sessionCount % 4 === 0 && sessionCount > 0) ? LONG_BREAK_DURATION : BREAK_DURATION;
+
   const progress = isBreak
-    ? ((BREAK_DURATION - timeLeft) / BREAK_DURATION) * 100
+    ? ((currentBreakDuration - timeLeft) / currentBreakDuration) * 100
     : ((WORK_DURATION - timeLeft) / WORK_DURATION) * 100;
 
   return { timeLeft, isRunning, isBreak, sessionCount, toggle, reset, format, progress };

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -4,9 +4,22 @@ import PomodoroTimer from "../components/Pomodoro/PomodoroTimer";
 import TaskModal from "../components/Task/TaskModal";
 import { useBoard } from "../context/BoardContext";
 
+const LoadingSpinner = () => (
+  <div className="flex items-center justify-center h-screen bg-[#0f0f10]">
+    <div className="flex flex-col items-center gap-4">
+      <div className="w-12 h-12 border-4 border-purple-600 border-t-transparent rounded-full animate-spin"></div>
+      <span className="text-[#a0a0a5] text-sm font-medium animate-pulse">Loading workspace...</span>
+    </div>
+  </div>
+);
+
 const Dashboard = () => {
-  const { user, logout, updateTask } = useBoard();
+  const { user, logout, updateTask, loading } = useBoard();
   const [selectedTask, setSelectedTask] = useState(null);
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
 
   const handleSessionComplete = async () => {
     if (selectedTask) {


### PR DESCRIPTION
## Fixes #8 and #11

This PR resolves two issues in the client application:

### 1. Fixes #8 - Added LoadingSpinner Component
* Extracted the  state from  context in .
* Created a simple  component inside  using Tailwind CSS spinner/pulsing animation styles.
* Rendered the spinner in the dashboard if the workspace is loading tasks from the database.

### 2. Fixes #11 - Added 15-minute Long Break after 4 sessions
* Introduced a  (15 minutes) constant in the  hook.
* Updated timer transition logic so that upon completing a work session, if  reaches a multiple of 4, a 15-minute long break is triggered instead of a 5-minute break.
* Corrected progress bar calculations to scale accurately based on  during a long break.
* Set the Pomodoro session count to reset to 0 upon reset trigger.
