### PR TITLE
Add copy button

### DIFF
--- a/devboard/README.md
+++ b/devboard/README.md
@@ -71,3 +71,4 @@ MIT — free to use, fork, and build on.
 ---
 
 Built with ❤️ by the community. Star ⭐ this repo if you find it useful!
+************

--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -76,21 +76,39 @@ const TaskCard = ({ task, index, onSelect }) => {
                   </button>
                 ))}
               </div>
+
+              {/* Updated Snippet Block with Copy Button */}
               {expanded && (
-                <SyntaxHighlighter
-                  language={
-                    task.snippets[selectedSnippet].language || "javascript"
-                  }
-                  style={vscDarkPlus}
-                  customStyle={{
-                    fontSize: 10,
-                    borderRadius: 6,
-                    margin: 0,
-                    padding: "8px 10px",
-                  }}
-                >
-                  {task.snippets[selectedSnippet].code}
-                </SyntaxHighlighter>
+                <>
+                  <div className="flex justify-end mb-1">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigator.clipboard.writeText(
+                          task.snippets[selectedSnippet].code
+                        );
+                      }}
+                      className="text-[10px] px-2 py-1 rounded bg-purple-600 text-white hover:bg-purple-700"
+                    >
+                      Copy
+                    </button>
+                  </div>
+
+                  <SyntaxHighlighter
+                    language={
+                      task.snippets[selectedSnippet].language || "javascript"
+                    }
+                    style={vscDarkPlus}
+                    customStyle={{
+                      fontSize: 10,
+                      borderRadius: 6,
+                      margin: 0,
+                      padding: "8px 10px",
+                    }}
+                  >
+                    {task.snippets[selectedSnippet].code}
+                  </SyntaxHighlighter>
+                </>
               )}
             </div>
           )}


### PR DESCRIPTION
## Description

- Added a Copy button for code snippets in TaskCard.
- Clicking the button copies the selected code snippet to the clipboard.

Fixes #58