### PR TITLE
Fix mobile responsive layout issue #72

### DIFF
--- a/devboard/client/src/components/Board/Column.jsx
+++ b/devboard/client/src/components/Board/Column.jsx
@@ -13,7 +13,7 @@ const Column = ({ columnId, tasks, onSelectTask, onAddTask }) => {
   const config = COLUMN_CONFIG[columnId];
 
   return (
-    <div className="flex flex-col w-56 flex-shrink-0">
+    <div className="flex flex-col w-full md:w-56 flex-shrink-0">
       {/* Header */}
       <div className="flex items-center justify-between mb-3 px-1">
         <div className="flex items-center gap-2">

--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -68,7 +68,7 @@ const KanbanBoard = ({ onSelectTask }) => {
   return (
     <>
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="flex gap-4 p-4 overflow-x-auto h-full">
+        <div className="flex flex-col md:flex-row gap-4 p-4 overflow-x-hidden md:overflow-x-auto overflow-y-auto h-full">
           {COLUMNS.map((col) => (
             <Column
               key={col}

--- a/devboard/package-lock.json
+++ b/devboard/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "devboard",
       "version": "1.0.0",
+      "dependencies": {
+        "canvas-confetti": "^1.9.4"
+      },
       "devDependencies": {
         "concurrently": "^8.2.0"
       }
@@ -45,6 +48,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
       }
     },
     "node_modules/chalk": {

--- a/devboard/package.json
+++ b/devboard/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.0"
+  },
+  "dependencies": {
+    "canvas-confetti": "^1.9.4"
   }
 }


### PR DESCRIPTION
<img width="340" height="767" alt="image" src="https://github.com/user-attachments/assets/9b9504d7-f06b-463e-bf96-676d6070e225" />

This PR improves the mobile responsiveness of the Kanban board.

### Changes
- Updated `KanbanBoard.jsx` to use `flex-col` on small screens and `md:flex-row` on larger screens.
- Updated `Column.jsx` to use `w-full` on mobile and `md:w-56` on desktop.
- Improved the layout so Kanban columns stack vertically on mobile devices and display horizontally on larger screens.

Fixes anoopcodehack/DevBoard#72

For the checklist:

✅ My code follows the project's style guidelines
✅ I tested my changes locally
⬜ I updated the README if my changes affect setup or usage
✅ My commit messages are clear and follow the conventional commit format