### PR TITLE
feat: show time ago on task cards

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -9,6 +9,14 @@ const PRIORITY_COLORS = {
   low: "bg-green-500/20 text-green-400",
 };
 
+const timeAgo = (date) => {
+  const diff = Date.now() - new Date(date);
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return "today";
+  if (days === 1) return "1 day ago";
+  return `${days} days ago`;
+};
+
 const TaskCard = ({ task, index, onSelect }) => {
   const [expanded, setExpanded] = useState(false);
   const [selectedSnippet, setSelectedSnippet] = useState(0);
@@ -149,6 +157,9 @@ const TaskCard = ({ task, index, onSelect }) => {
               {task.pomodoroCount > 0 && <span>🍅 ×{task.pomodoroCount}</span>}
               {task.snippets?.length > 0 && (
                 <span>📎 {task.snippets.length}</span>
+              )}
+              {task.createdAt && (
+                <span>🕐 {timeAgo(task.createdAt)}</span>
               )}
             </div>
             {task.assignee?.name && (


### PR DESCRIPTION
## Summary\n\nThis PR resolves #79 by showing how long ago a task was created on the card.\n\n## Changes\n\n- Added timeAgo() function that returns:\n  - today for same-day tasks\n  - 1 day ago for yesterday\n  - X days ago for older tasks\n- Display in card footer with clock icon\n- No external package needed\n\n## Verification\n\n- [x] timeAgo function works correctly\n- [x] Displayed in card footer\n- [x] No external dependencies