### PR TITLE
feat: highlight overdue tasks with red styling

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -18,6 +18,7 @@ const TaskCard = ({ task, index, onSelect }) => {
   today.setHours(0, 0, 0, 0);
   const dueDate = new Date(task.dueDate);
   const isOverdue = task.dueDate && dueDate < today && task.status !== "done";
+  // const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && task.status !== "Done";
   // ------------------
 
   return (
@@ -29,7 +30,8 @@ const TaskCard = ({ task, index, onSelect }) => {
           {...provided.dragHandleProps}
           onClick={() => onSelect(task)}
           className={`bg-[var(--bg-card)] border rounded-lg p-3 cursor-pointer transition-all
-            ${snapshot.isDragging ? "border-purple-500 shadow-lg shadow-purple-500/10" : "border-[var(--border-primary)] hover:border-[#444]"}`}
+            ${snapshot.isDragging ? "border-purple-500 shadow-lg shadow-purple-500/10" : isOverdue
+      ? "border-red-500 border-l-4 hover:border-red-400": "border-[var(--border-primary)] hover:border-[#444]"}`}
         >
           {/* Title */}
           <p className="text-sm font-medium text-[#f0f0f0] leading-snug mb-2">


### PR DESCRIPTION
Closes #95

- Added a red border for overdue task cards.
- Reused the existing overdue detection logic without modifying the existing business logic.

Testing
- Verified overdue tasks are highlighted correctly.
- Verified non-overdue tasks remain unchanged.
- Verified completed tasks are not highlighted.

<img width="686" height="295" alt="Screenshot 2026-07-30 122758" src="https://github.com/user-attachments/assets/1140db6a-7bb0-4828-ac55-f83f1fad70bd" />
