### PR TITLE
Add Delete button with confirmation dialog to TaskModal

### DIFF
--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useBoard } from "../../context/BoardContext";
 
 const TaskModal = ({
   task,
@@ -24,6 +25,7 @@ const TaskModal = ({
   // AI Loading & Error States
   const [isGenerating, setIsGenerating] = useState(false);
   const [aiError, setAiError] = useState("");
+  const { deleteTask } = useBoard();
 
   const handleGenerateAI = async () => {
     if (!form.title.trim()) {
@@ -237,6 +239,17 @@ const TaskModal = ({
           >
             Cancel
           </button>
+          <button
+            onClick={async () => {
+            if (window.confirm('Delete this task?')) {
+             await deleteTask(task._id)
+             onClose()
+                }
+             }}
+            className="px-4 py-2 text-sm text-red-400 hover:text-red-300 transition"
+          >
+  Delete
+</button>
           <button
             onClick={handleSave}
             disabled={loading || !form.title.trim()}


### PR DESCRIPTION
## Summary

- Added a Delete button to the Task modal.
- Added a confirmation dialog before deleting a task.
- Reused the existing `deleteTask` function from `BoardContext`.

Fixes #94