### PR TITLE
feat: add ability to delete snippets from task edit modal

### DIFF
--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -6,6 +6,7 @@ const TaskModal = ({
   defaultStatus = "backlog",
   onClose,
   onSave,
+  updateTask,
 }) => {
   const [form, setForm] = useState({
     title: task?.title || "",
@@ -58,6 +59,11 @@ const TaskModal = ({
     } finally {
       setIsGenerating(false);
     }
+  };
+
+  const handleDeleteSnippet = async (indexToRemove) => {
+    const updatedSnippets = task.snippets.filter((_, i) => i !== indexToRemove);
+    await updateTask(task._id, { snippets: updatedSnippets });
   };
 
   const handleSave = async () => {
@@ -189,7 +195,20 @@ const TaskModal = ({
             />
           </div>
 
-          {/* Code Snippet */}
+          {/* Existing Snippets */}
+          {task?.snippets?.map((snippet, index) => (
+            <div key={index} className="flex items-center justify-between bg-[#0f0f10] rounded-lg px-3 py-2 mb-2">
+              <span className="text-xs font-mono text-[#888]">{snippet.language} snippet</span>
+              <button
+                onClick={() => handleDeleteSnippet(index)}
+                className="text-red-400 hover:text-red-300 text-xs"
+              >
+                ✕ Remove
+              </button>
+            </div>
+          ))}
+
+          {/* Add Code Snippet */}
           <div className="border border-[var(--border-primary)] rounded-lg overflow-hidden">
             <div className="flex items-center justify-between px-3 py-2 bg-[var(--bg-primary)] border-b border-[var(--border-primary)]">
               <span className="text-xs text-[#888]">{"</>"} Code Snippet</span>

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -114,6 +114,7 @@ const Dashboard = () => {
             await updateTask(selectedTask._id, data);
             setSelectedTask(null);
           }}
+          updateTask={updateTask}
         />
       )}
       {/* Create First Task Modal */}


### PR DESCRIPTION
## What
Add a delete button for each snippet in the task edit modal so users can remove snippets they no longer need.

## Why
Once a snippet was added to a task, there was no way to remove it from the UI.

## Changes
- `client/src/components/Task/TaskModal.jsx` — render existing snippets with ✕ Remove button, add handleDeleteSnippet handler
- `client/src/pages/Dashboard.jsx` — pass updateTask prop to TaskModal

## How to test
1. Create a task with a snippet
2. Click the task card to open edit modal — snippet shows with ✕ Remove
3. Click ✕ Remove — snippet is deleted immediately