### PR TITLE
feat: add skeleton loader for dashboard

### DIFF
--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -5,15 +5,6 @@ import TaskModal from "../components/Task/TaskModal";
 import Heatmap from "../components/Heatmap/Heatmap";
 import { useBoard } from "../context/BoardContext";
 
-const LoadingSpinner = () => (
-  <div className="flex items-center justify-center h-screen bg-[var(--bg-primary)]">
-    <div className="flex flex-col items-center gap-4">
-      <div className="w-12 h-12 border-4 border-purple-600 border-t-transparent rounded-full animate-spin"></div>
-      <span className="text-[#a0a0a5] text-sm font-medium animate-pulse">Loading workspace...</span>
-    </div>
-  </div>
-);
-
 const Dashboard = () => {
   const { user, logout, updateTask, loading, searchQuery, setSearchQuery, tasks, addTask, activeTag, setActiveTag } = useBoard();
   useEffect(() => {
@@ -23,7 +14,20 @@ const Dashboard = () => {
   const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
 
   if (loading) {
-    return <LoadingSpinner />;
+    return (
+      <div className="flex gap-4 p-4">
+        {[1, 2, 3, 4].map((col) => (
+          <div key={col} className="flex flex-col w-56 gap-2">
+            {[1, 2, 3].map((card) => (
+              <div
+                key={card}
+                className="animate-pulse bg-[#2a2a2f] rounded-lg h-20 w-full"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    );
   }
 
   const handleSessionComplete = async () => {


### PR DESCRIPTION
## What does this PR do?

This PR replaces the full-screen loading spinner on the dashboard with a skeleton loading UI that matches the Kanban board layout.

The implementation uses the existing `loading` state from `BoardContext` to display placeholder columns and cards while the board data is being loaded, providing a smoother user experience.

## Closes

- Closes #124

## Type of change(s)

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Style / UI change
- [ ] Refactor (no functional change)
- [ ] Performance improvement
- [ ] Other

## Checklist

- [x] I've tested this change locally and it works as expected
- [ ] `bun run lint` or `npm run lint` completes without warnings or errors
- [ ] `bun run build` or `npm run build` completes successfully
- [x] My commit messages follow Conventional Commits (e.g. `feat: ...`, `fix: ...`, `chore: ...`)
- [ ] I've updated relevant documentation (README, comments, etc.) if needed
- [x] I've removed any temporary debugging code (e.g. `console.log`)

## Screenshots / recordings (if applicable)

N/A

## Anything else the reviewer should know?

The implementation reuses the existing `loading` state from `BoardContext` and replaces the loading spinner with a lightweight skeleton loader that reflects the dashboard layout.