### PR TITLE
Feat: add Auto-suggest tags from attached code snippets

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -3,6 +3,7 @@ import { Draggable } from "@hello-pangea/dnd";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { useBoard } from "../../context/BoardContext";
+import { useSuggestTags } from "../../hooks/useSuggestTags";
 
 const PRIORITY_COLORS = {
   high: "bg-red-500/20 text-red-400",
@@ -21,7 +22,8 @@ const timeAgo = (date) => {
 const TaskCard = ({ task, index, onSelect }) => {
   const [expanded, setExpanded] = useState(false);
   const [selectedSnippet, setSelectedSnippet] = useState(0);
-  const { activeTag, setActiveTag } = useBoard();
+  const { activeTag, setActiveTag , updateTask } = useBoard();
+  const { suggestedTags,loadingTags,handleSuggestTags,handleAddTag } = useSuggestTags(task,selectedSnippet,updateTask);
 
   // Check if the task due date has passed and the task is not completed ---------
   const today = new Date();
@@ -63,8 +65,9 @@ const TaskCard = ({ task, index, onSelect }) => {
 
           {/* Code snippets preview */}
           {task.snippets?.length > 0 && (
-            <div className="mb-2">
-              <button
+            <div className=" mb-2">
+              <div className="flex items-center justify-between mb-1">
+                 <button
                 onClick={(e) => {
                   e.stopPropagation();
                   setExpanded((v) => !v);
@@ -74,6 +77,17 @@ const TaskCard = ({ task, index, onSelect }) => {
                 {"</>"} {task.snippets.length} snippet
                 {task.snippets.length > 1 ? "s" : ""} {expanded ? "▲" : "▼"}
               </button>
+
+                <button
+                 onClick={handleSuggestTags}
+                 disabled={loadingTags}
+                  className="text-[10px] px-2 py-1 rounded bg-purple-600 text-white hover:bg-purple-700"
+                >
+                  {loadingTags ? "Loading..." : "Suggest tags"}
+                </button>
+              </div>
+             
+
               <div className="flex gap-1 mb-2">
                 {task.snippets.map((snippet, index) => (
                   <button
@@ -88,6 +102,24 @@ const TaskCard = ({ task, index, onSelect }) => {
                   </button>
                 ))}
               </div>
+
+                {suggestedTags.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mb-2">
+                      {suggestedTags.map((tag) => (
+                        <button
+                          key={tag}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleAddTag(tag);
+                          }}
+                           className="text-[10px] px-2 py-0.5 rounded bg-purple-500/20 text-purple-300 border border-purple-500/40 hover:bg-purple-500/40"
+                        >
+                          + {tag}
+                        </button>
+                      ))}
+                  </div>
+                )}
+
 
               {/* Updated Snippet Block with Copy Button */}
               {expanded && (

--- a/devboard/client/src/hooks/useSuggestTags.jsx
+++ b/devboard/client/src/hooks/useSuggestTags.jsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import axios from "axios";
+
+export const useSuggestTags = (task, selectedSnippet, updateTask) =>{
+    const [suggestedTags, setSuggestedTags] = useState([]);
+    const [loadingTags, setLoadingTags] = useState(false);
+
+const handleSuggestTags = async (e) => {
+    e.stopPropagation();
+    setLoadingTags(true);
+
+
+    try{
+        const { data } = await axios.post("/api/ai/suggest-tags", {
+                code: task.snippets[selectedSnippet].code,
+        });
+
+        setSuggestedTags(data.tags);
+    } catch(err){
+        console.error("suggest-tags failed:",err);
+    } finally {
+        setLoadingTags(false);
+    }
+}
+const handleAddTag = (tag) => {
+    const alreadyExist = task.tags?.some(
+        (t) => t.toLowerCase() === tag.toLowerCase()
+    );
+    if(alreadyExist) return;
+
+    updateTask(task._id, { tags:[...(task.tags || []),tag]});
+    setSuggestedTags((prev)=> prev.filter((t)=> t !== tag));
+}
+
+
+    return {suggestedTags,loadingTags,handleSuggestTags,handleAddTag};
+}

--- a/devboard/server/routes/ai.js
+++ b/devboard/server/routes/ai.js
@@ -28,4 +28,58 @@ router.post('/generate-description', async (req, res) => {
   }
 });
 
+
+router.post('/suggest-tags', async (req,res) =>{
+try {
+  const { code } = req.body;
+  if(!code || typeof code !== 'string' || code.trim().length === 0){
+    return res.status(400).json({error:'Code snippet is required for tag generation'});
+  }
+  const systemPrompt =`You are a code tagging assistant. Analyze the given code snippet and return exactly 2-3 short, relevant tags.
+
+Rules:
+- Tags must reflect the snippet's actual language, framework, or core concept (e.g. "javascript", "react-hooks", "recursion", "async-await", "sql-join")
+- Prefer specific tags over generic ones (avoid just "code" or "programming")
+- Use lowercase, hyphenated format (e.g. "error-handling" not "Error Handling")
+- Return ONLY a raw JSON array of strings, nothing else — no markdown, no explanation, no code fences
+
+Example output: ["python", "list-comprehension", "data-processing"]`;
+
+const userPrompt =`Code snippet:\n\n${code}`;
+
+const fullPrompt =`${systemPrompt}\n\n${userPrompt}`;
+
+const response = await ai.models.generateContent({
+  model:'gemini-3.6-flash',
+  contents:fullPrompt,
+})
+const rawResponseText = response.text ? response.text.trim() : '[]';
+
+const cleanedResponseText = rawResponseText.replace(/```json|```/g,'').trim();
+
+let parsedTags;
+try{
+  parsedTags = JSON.parse(cleanedResponseText);
+
+}catch(err){
+  const match = cleanedResponseText.match(/\[.*\]/s);
+  parsedTags = match ? JSON.parse(match[0]) : [];
+}
+let suggestedTags = parsedTags;
+if(!Array.isArray(suggestedTags)) suggestedTags = [];
+
+suggestedTags = suggestedTags
+  .filter(t => typeof t === 'string' && t.trim().length > 0)
+  .map(t => t.trim().toLowerCase())
+  .filter((t,i,arr)=> arr.indexOf(t) === i)
+  .slice(0,3)
+
+  return res.status(200).json({tags:suggestedTags});
+}catch(err){
+  console.error('Error generating tags with AI:',err);
+  return res.status(500).json({error:'Failed to generate tag suggestions'})
+}
+
+})
+
 module.exports = router;


### PR DESCRIPTION
## Auto-suggest tags from attached code snippets 🏷️

Adds a "Suggest Tags" button near a task's code snippet that analyzes the snippet using Gemini and returns 2-3 relevant tags as clickable chips.

### Changes
- **Backend:** New `POST /api/ai/suggest-tags` route accepts `{ code }`, prompts Gemini for 2-3 relevant tags, returns a clean sanitized array
- **Frontend:** New `useSuggestTags` custom hook encapsulating state (`suggestedTags`, `loadingTags`) and handlers (`handleSuggestTags`, `handleAddTag`)
- **UI:** "Suggest Tags" button added in `TaskCard.jsx`'s code snippet section, rendering suggestions as clickable chips

### Tasks completed
- [x] Add "Suggest Tags" button in code snippet section of task card
- [x] Create `POST /api/ai/suggest-tags` route (backend)
- [x] Route accepts `{ code }`, prompts LLM for 2-3 tags, returns array
- [x] Render suggestions as clickable chips
- [x] Clicking a chip adds it to the task's tags

### Acceptance Criteria
- ✅ Button only shows when a code snippet is attached
- ✅ Suggested tags are relevant to the snippet's language/content
- ✅ Adding a tag doesn't duplicate existing ones (case-insensitive check)

### Testing done
- Backend route tested via Postman (valid input + empty input edge case)
- Full flow tested in browser: button click -> loading state -> chips render -> click to add -> duplicate prevention verified

### Files touched
- `client/src/components/Board/TaskCard.jsx`
- `client/src/hooks/useSuggestTags.jsx` (new)
- `server/routes/ai.js`

Closes #120 

---
Started working on this since I hadn't heard back on my earlier message happy to adjust the approach based on your feedback! 🙂