### PR TITLE
feat: limit tag input length and truncate long task tags

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -147,7 +147,7 @@ const TaskCard = ({ task, index, onSelect }) => {
                     : "bg-[var(--border-primary)] text-[#888] hover:bg-[var(--border-primary)]/80"
                   }`}
               >
-                {tag}
+                {tag.length > 15 ? tag.slice(0, 15) + "..." : tag}
               </span>
             ))}
           </div>

--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -170,6 +170,7 @@ const TaskModal = ({
 
           <input
             type="text"
+            maxLength={20}
             placeholder="Tags (comma separated: react, api, bug)"
             value={form.tags}
             onChange={(e) => setForm({ ...form, tags: e.target.value })}


### PR DESCRIPTION
## Summary

- Added a 20-character limit to the tags input in `TaskModal.jsx`.
- Truncated tags longer than 15 characters in `TaskCard.jsx`.

## Testing

- Verified the tags input cannot exceed 20 characters.
- Verified tags longer than 15 characters are displayed with `...`.