### PR TITLE
fix: normalize task tags

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -166,22 +166,25 @@ const TaskCard = ({ task, index, onSelect }) => {
                 {task.priority}
               </span>
             )}
-            {task.tags?.map((tag) => (
-              <span
-                key={tag}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveTag(activeTag === tag ? null : tag);
-                }}
-                className={`text-[10px] px-1.5 py-0.5 rounded cursor-pointer transition
-                  ${activeTag === tag
-                    ? "bg-purple-600/30 text-purple-300 ring-1 ring-purple-500"
-                    : "bg-[var(--border-primary)] text-[#888] hover:bg-[var(--border-primary)]/80"
-                  }`}
-              >
-                {tag.length > 15 ? tag.slice(0, 15) + "..." : tag}
-              </span>
-            ))}
+            {task.tags?.map((tag) => {
+              const t = tag.trim(); // legacy rows may hold untrimmed tags
+              return (
+                <span
+                  key={t}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveTag(activeTag === tag ? null : tag);
+                  }}
+                  className={`text-[10px] px-1.5 py-0.5 rounded cursor-pointer transition
+                    ${activeTag === tag
+                      ? "bg-purple-600/30 text-purple-300 ring-1 ring-purple-500"
+                      : "bg-[var(--border-primary)] text-[#888] hover:bg-[var(--border-primary)]/80"
+                    }`}
+                >
+                  {t.length > 15 ? t.slice(0, 15) + "..." : t}
+                </span>
+              );
+            })}
           </div>
 
           {/* Due date */}

--- a/devboard/server/models/Task.js
+++ b/devboard/server/models/Task.js
@@ -32,4 +32,17 @@ const taskSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+// Normalize tags at the API boundary: trim whitespace, drop empties, dedupe.
+// Tags arrive from the modal, GitHub import, and AI suggestions — whitespace
+// differences must not create distinct tags (e.g. "react " vs "react").
+const sanitizeTags = (tags) => {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter((t) => typeof t === "string")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .filter((t, i, arr) => arr.indexOf(t) === i);
+};
+
 module.exports = mongoose.model("Task", taskSchema);
+module.exports.sanitizeTags = sanitizeTags;

--- a/devboard/server/routes/github.js
+++ b/devboard/server/routes/github.js
@@ -43,7 +43,7 @@ router.post("/import", protect, async (req, res) => {
       title,
       githubIssueUrl,
       githubIssueNumber,
-      tags: tags || [],
+      tags: Task.sanitizeTags(tags),
       status: "backlog",
     });
     res.status(201).json(task);

--- a/devboard/server/routes/tasks.js
+++ b/devboard/server/routes/tasks.js
@@ -16,7 +16,10 @@ router.get("/", protect, async (req, res) => {
 // POST /api/tasks — create task
 router.post("/", protect, async (req, res) => {
   try {
-    const task = await Task.create(req.body);
+    const task = await Task.create({
+      ...req.body,
+      tags: Task.sanitizeTags(req.body.tags),
+    });
     res.status(201).json(task);
   } catch (err) {
     res.status(400).json({ message: err.message });
@@ -26,7 +29,13 @@ router.post("/", protect, async (req, res) => {
 // PUT /api/tasks/:id — update task (status, content, etc.)
 router.put("/:id", protect, async (req, res) => {
   try {
-    const updatedTask = await Task.findByIdAndUpdate(req.params.id, req.body, {
+    // Only touch tags when the caller sends them — partial updates like
+    // { pomodoroCount } or { status, order } must not wipe existing tags.
+    const updates = { ...req.body };
+    if (req.body.tags !== undefined) {
+      updates.tags = Task.sanitizeTags(req.body.tags);
+    }
+    const updatedTask = await Task.findByIdAndUpdate(req.params.id, updates, {
       new: true,
     }).populate("assignee", "name email avatar");
     if (!updatedTask) return res.status(404).json({ message: "Task not found" });


### PR DESCRIPTION
## What does this PR do?

Fixes task tags containing leading/trailing whitespace.

### Changes

* Normalize tags at the server API boundary by trimming whitespace.
* Remove empty tags and duplicate tags after normalization.
* Apply normalization to task creation and updates.
* Normalize tags imported from GitHub issues.
* Trim legacy tags when rendering them in `TaskCard`.

### Why?

Previously, values such as `react` and `react ` could be stored as separate tags, causing inconsistent tag display and filtering.

This fixes the problem at the write boundary while also handling legacy data during rendering.

### Validation

* `sanitizeTags` assertions passed.
* Server route loading checks passed.
* Client production build passed.
* `git diff --check` passed.

Closes #177
