### PR TITLE
fix: show "Copied! ✅" feedback on snippet copy button

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -22,6 +22,7 @@ const timeAgo = (date) => {
 const TaskCard = ({ task, index, onSelect }) => {
   const [expanded, setExpanded] = useState(false);
   const [selectedSnippet, setSelectedSnippet] = useState(0);
+  const [copied, setCopied] = useState(false);
   const { activeTag, setActiveTag , updateTask } = useBoard();
   const { suggestedTags,loadingTags,handleSuggestTags,handleAddTag } = useSuggestTags(task,selectedSnippet,updateTask);
 
@@ -131,10 +132,12 @@ const TaskCard = ({ task, index, onSelect }) => {
                         navigator.clipboard.writeText(
                           task.snippets[selectedSnippet].code
                         );
+                        setCopied(true);
+                        setTimeout(() => setCopied(false), 2000);
                       }}
                       className="text-[10px] px-2 py-1 rounded bg-purple-600 text-white hover:bg-purple-700"
                     >
-                      Copy
+                      {copied ? "Copied! ✅" : "Copy"}
                     </button>
                   </div>
 


### PR DESCRIPTION
Fixes #181

Clicking the snippet Copy button on a task card previously gave no feedback, so there was no way to tell whether the copy succeeded.

**What changed** (`client/src/components/Board/TaskCard.jsx`):
- Added a `copied` state to `TaskCard`
- On click, the button copies the snippet as before, then flips its label to "Copied! ✅" and reverts to "Copy" after 2 seconds

This follows the inline-feedback approach suggested in the issue (the app has no toast library, so the button itself provides the feedback, keeping styling untouched).

**Verified:** `npm run build` passes in `devboard/client`.