### PR TITLE
feat: show pending task count in browser tab

### DIFF
--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -21,13 +21,19 @@ activeTag,
 setActiveTag,
 } = useBoard();
 
+const inProgressCount = tasks.filter(
+  (task) => task.status === "inprogress"
+).length;
+
 
 
 useEffect(() => {
 
-document.title = "Dashboard — DevBoard";
+document.title = inProgressCount > 0
+  ? `(${inProgressCount}) DevBoard`
+  : "DevBoard";
 
-}, []);
+}, [inProgressCount]);
 
 
 


### PR DESCRIPTION
## Summary

- Show the number of in-progress tasks in the browser tab title.
- Reset the title to `DevBoard` when no tasks are in progress.

## Why

This keeps the active workload visible when the dashboard tab is in the background.

Closes #202

## Impact

Frontend-only title update; no API or persistence changes.

## Testing

- `pnpm run build` (Vite production build, 1,289 modules transformed)
- `git diff --check`
