### PR TITLE
feat: show relative updatedAt time on task card footer

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -13,10 +13,13 @@ const PRIORITY_COLORS = {
 
 const timeAgo = (date) => {
   const diff = Date.now() - new Date(date);
+  const mins = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
   const days = Math.floor(diff / 86400000);
-  if (days === 0) return "today";
-  if (days === 1) return "1 day ago";
-  return `${days} days ago`;
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  return `${days}d ago`;
 };
 
 const TaskCard = ({ task, index, onSelect }) => {
@@ -102,7 +105,7 @@ const TaskCard = ({ task, index, onSelect }) => {
 
           {/* GitHub issue link */}
           {task.githubIssueUrl && (
-            <a
+            
               href={task.githubIssueUrl}
               target="_blank"
               rel="noopener noreferrer"
@@ -265,6 +268,13 @@ const TaskCard = ({ task, index, onSelect }) => {
               </div>
             )}
           </div>
+
+          {/* Last updated */}
+          {task.updatedAt && (
+            <div className="mt-1 text-[10px] text-[#666]">
+              ✏️ updated {timeAgo(task.updatedAt)}
+            </div>
+          )}
 
           {/* Context menu */}
           {contextMenu && (


### PR DESCRIPTION
## Summary
Adds a relative "updated X ago" timestamp below the task card footer, so it's clear at a glance whether a card was edited recently or weeks ago.

## Changes
- `client/src/components/Board/TaskCard.jsx`
  - Extended `timeAgo` to return minutes/hours/days (previously only "today" / "N days ago")
  - Added a new line below the card footer showing `✏️ updated {timeAgo(task.updatedAt)}`, using the existing `updatedAt` 

## Notes
- Focused, frontend-only change

Closes #193