### PR TITLE
feat: add assignee filter to dashboard

### DIFF
--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -7,8 +7,9 @@ import confetti from "canvas-confetti";
 
 const COLUMNS = ["backlog", "inprogress", "review", "done"];
 
-const KanbanBoard = ({ onSelectTask, activeCol }) => {
+const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol }) => {
   const { tasks, updateTask, addTask } = useBoard();
+  const displayedTasks = filteredTasks ?? tasks;
   const [modalOpen, setModalOpen] = useState(false);
   const [defaultStatus, setDefaultStatus] = useState("backlog");
 
@@ -35,7 +36,7 @@ const KanbanBoard = ({ onSelectTask, activeCol }) => {
   }, []);
 
   const getTasksByStatus = (status) =>
-    tasks.filter((t) => t.status === status).sort((a, b) => a.order - b.order);
+    displayedTasks.filter((t) => t.status === status).sort((a, b) => a.order - b.order);
 
   const onDragEnd = async (result) => {
     const { destination, source, draggableId } = result;

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -40,7 +40,16 @@ const [showScrollTop, setShowScrollTop] = useState(false);
 
 const [activeCol, setActiveCol] = useState(0);
 
+const [assigneeFilter, setAssigneeFilter] = useState("all");
 
+const assignees = [
+  ...new Set(tasks.map((task) => task.assignee?.name).filter(Boolean)),
+].sort();
+
+const filteredTasks = tasks.filter(
+  (task) =>
+    assigneeFilter === "all" || task.assignee?.name === assigneeFilter,
+);
 
 
 
@@ -240,9 +249,9 @@ beta
 
 <span className="text-sm text-[#a0a0a5]">
 
-{tasks.length}
+{filteredTasks.length}
 
-{tasks.length === 1 ? " task" : " tasks"}
+{filteredTasks.length === 1 ? " task" : " tasks"}
 
 </span>
 
@@ -266,9 +275,19 @@ className="text-xs bg-purple-600/30 text-purple-300 px-2 py-0.5 rounded-full fle
 
 )}
 
-
-
-
+<select
+  value={assigneeFilter}
+  onChange={(e) => setAssigneeFilter(e.target.value)}
+  aria-label="Filter tasks by assignee"
+  className="bg-[#2a2a2f] text-[#888] text-xs rounded-lg px-2 py-1.5 border border-[#333]"
+>
+  <option value="all">All Members</option>
+  {assignees.map((name) => (
+    <option key={name} value={name}>
+      {name}
+    </option>
+  ))}
+</select>
 
 
 <input
@@ -408,6 +427,7 @@ className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2.5 rounded-lg"
 
 
 <KanbanBoard 
+tasks={filteredTasks}
 onSelectTask={setSelectedTask}
 activeCol={activeCol}
 />


### PR DESCRIPTION
## Summary

* add an assignee filter to the dashboard navbar
* populate the filter with unique, sorted assignee names from existing tasks
* filter the displayed task count and Kanban board
* preserve the existing search and tag filters
* keep the default view showing all members

## Testing

* changed JSX files compiled successfully with esbuild
* `git diff --check` passed
* full `npm run build` is currently blocked by a pre-existing syntax error in `TaskCard.jsx` on `main` (missing opening `<a>` tag near line 109)

Closes #219
