### PR TITLE
feat: show online user count

### DIFF
--- a/devboard/client/src/context/BoardContext.jsx
+++ b/devboard/client/src/context/BoardContext.jsx
@@ -14,6 +14,7 @@ export const BoardProvider = ({ children }) => {
   const [allTasks, setAllTasks] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
+  const [onlineUsers, setOnlineUsers] = useState(0);
 
   const [activeTag, setActiveTag] = useState(null);
 
@@ -68,9 +69,15 @@ export const BoardProvider = ({ children }) => {
 
   // Real-time board sync via Socket.IO
   useEffect(() => {
-    if (!user) return;
+    if (!user) {
+      setOnlineUsers(0);
+      return;
+    }
 
     const socket = io("http://localhost:5000");
+
+    socket.on("users:online", setOnlineUsers);
+    socket.on("disconnect", () => setOnlineUsers(0));
 
     socket.on("task:updated", (updatedTask) => {
       setAllTasks((prev) =>
@@ -185,6 +192,7 @@ export const BoardProvider = ({ children }) => {
         tasks,
         loading,
         user,
+        onlineUsers,
         searchQuery,
         setSearchQuery,
         activeTag,

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ const Dashboard = () => {
 
 const {
 user,
+onlineUsers,
 logout,
 updateTask,
 deleteTask,
@@ -245,6 +246,11 @@ beta
 
 
 <div className="flex items-center gap-4">
+
+
+<span className="text-sm text-[#a0a0a5]">
+🟢 {onlineUsers} online
+</span>
 
 
 <span className="text-sm text-[#a0a0a5]">

--- a/devboard/server/index.js
+++ b/devboard/server/index.js
@@ -36,8 +36,17 @@ app.use("/api/ai", require("./routes/ai"));
 
 app.get("/", (req, res) => res.json({ message: "DevBoard API running 🚀" }));
 
+const onlineSockets = new Set();
+
 io.on("connection", (socket) => {
   console.log("client connected:", socket.id);
+  onlineSockets.add(socket.id);
+  io.emit("users:online", onlineSockets.size);
+
+  socket.on("disconnect", () => {
+    onlineSockets.delete(socket.id);
+    io.emit("users:online", onlineSockets.size);
+  });
 });
 
 mongoose


### PR DESCRIPTION
## Summary

- track connected Socket.IO clients and broadcast the current count on connect and disconnect
- reuse the dashboard's existing Socket.IO connection through `BoardContext`
- show the live count in the dashboard navbar

Reusing the existing connection avoids opening a second socket per dashboard and double-counting each active session.

## Verification

- Socket.IO smoke against the actual server handler: two clients observed `1 -> 2 -> 1`
- `node --check` for the server entry point and touched route dependencies
- standalone esbuild parse for the modified Dashboard and BoardContext JSX
- `git diff --check`

`npm run build` is currently blocked by a pre-existing syntax error in the unmodified `devboard/client/src/components/Board/TaskCard.jsx:109`; the same error is present on base commit `365de8e48034f6b188b7cb90a0dd17d144a20011`.

Closes #242
