### PR TITLE
Close task modal when browser back button is pressed

### DIFF
--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useBoard } from "../../context/BoardContext";
 
 const TaskModal = ({
@@ -67,6 +67,13 @@ const TaskModal = ({
     const updatedSnippets = task.snippets.filter((_, i) => i !== indexToRemove);
     await updateTask(task._id, { snippets: updatedSnippets });
   };
+
+  useEffect(() => {
+    window.history.pushState(null, "", window.location.href);
+    const handlePop = () => onClose();
+    window.addEventListener("popstate", handlePop);
+    return () => window.removeEventListener("popstate", handlePop);
+  }, []);
 
   const handleSave = async () => {
     if (!form.title.trim()) return;
@@ -265,15 +272,15 @@ const TaskModal = ({
           </button>
           <button
             onClick={async () => {
-            if (window.confirm('Delete this task?')) {
-             await deleteTask(task._id)
-             onClose()
-                }
-             }}
+              if (window.confirm('Delete this task?')) {
+                await deleteTask(task._id)
+                onClose()
+              }
+            }}
             className="px-4 py-2 text-sm text-red-400 hover:text-red-300 transition"
           >
-  Delete
-</button>
+            Delete
+          </button>
           <button
             onClick={handleSave}
             disabled={loading || !form.title.trim()}


### PR DESCRIPTION
## Summary

Adds browser back-button handling to the task modal. When the modal is open, pressing Back now closes it instead of navigating away from the board.

## Changes

* Added a `popstate` event listener when the modal opens
* Added a temporary browser history entry
* Removed the event listener when the modal closes

## Testing

* [ ] Opened the Create Task modal and pressed Back
* [ ] Opened the Edit Task modal and pressed Back
* [ ] Confirmed the modal closes without leaving the board
* [ ] Confirmed the normal close button still works
* [ ] Tested in mobile or responsive mode

Closes: #257