### PR TITLE
feat: add Helmet security headers

### DIFF
--- a/devboard/server/index.js
+++ b/devboard/server/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const http = require("http");
 const mongoose = require("mongoose");
 const cors = require("cors");
+const helmet = require("helmet");
 const dotenv = require("dotenv");
 const { rateLimit } = require("express-rate-limit");
 const { Server } = require("socket.io");
@@ -24,6 +25,7 @@ const io = new Server(server, {
 // Make io available to route handlers (req.app.get("io"))
 app.set("io", io);
 
+app.use(helmet());
 app.use(cors());
 app.use(express.json());
 app.use(limiter);

--- a/devboard/server/package-lock.json
+++ b/devboard/server/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "express-rate-limit": "^8.6.2",
+        "helmet": "^8.3.0",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^7.8.11",
         "socket.io": "^4.8.3"
@@ -993,6 +994,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/http-errors": {

--- a/devboard/server/package.json
+++ b/devboard/server/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-rate-limit": "^8.6.2",
+    "helmet": "^8.3.0",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.8.11",
     "socket.io": "^4.8.3"


### PR DESCRIPTION
## Summary

- add Helmet as a backend dependency
- register Helmet before the other Express middleware so its secure HTTP headers apply to every route

## Why

The backend did not set common security response headers. Helmet adds defaults that help reduce exposure to issues such as clickjacking and MIME-type sniffing.

Closes #261

## Testing

- `node --check index.js`
- `npm ls helmet --depth=0`
- ran a local HTTP smoke test against `/` and verified HTTP 200 plus Content Security Policy, `X-Content-Type-Options: nosniff`, and `X-Frame-Options: SAMEORIGIN`
