### PR TITLE
Show word count on task description

### DIFF
--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -151,6 +151,13 @@ const TaskModal = ({
               className="w-full bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded-lg px-3 py-2 text-sm text-[#f0f0f0] placeholder-[#555] focus:outline-none focus:border-purple-500 resize-none"
             />
 
+            <p className="text-[10px] text-[#666] mt-1">
+              {form.description.trim().split(/\s+/).filter(Boolean).length} word
+              {form.description.trim().split(/\s+/).filter(Boolean).length !== 1
+                ? "s"
+                : ""}
+            </p>
+
             {aiError && (
               <p className="text-xs text-red-400 mt-1">{aiError}</p>
             )}


### PR DESCRIPTION
Fixes #277

Adds a live word count below the description in `client/src/components/Task/TaskModal.jsx`: splits the description on whitespace, filters empties, and shows 'N word(s)' with correct pluralization. JSX verified with esbuild.