### PR TITLE
feat: add No tasks found message when search returns empty (#273)

### DIFF
--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -38,6 +38,8 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol }) => {
   const getTasksByStatus = (status) =>
     displayedTasks.filter((t) => t.status === status).sort((a, b) => a.order - b.order);
 
+  const isEmpty = COLUMNS.every(col => getTasksByStatus(col).length === 0);
+
   const onDragEnd = async (result) => {
     const { destination, source, draggableId } = result;
 
@@ -176,24 +178,34 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol }) => {
 
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="flex flex-col md:flex-row gap-4 p-4 overflow-x-hidden md:overflow-x-auto overflow-y-auto h-full">
-          {columns.map((col) => (
-            <Column
-              key={col}
-              columnId={col}
-              tasks={getTasksByStatus(col)}
-              onSelectTask={onSelectTask}
-              onAddTask={handleAddTask}
-              isActive={columns.indexOf(col) === activeCol}
-            />
-          ))}
-          <button
-            className="flex"
-            onClick={() => {
-              setShowinput(true);
-            }}
-          >
-            + Add Column
-          </button>
+          {isEmpty ? (
+            <div className="flex flex-col items-center justify-center w-full h-64 text-gray-500">
+              <span className="text-4xl mb-4">🔍</span>
+              <h3 className="text-xl font-semibold mb-2">No tasks found!</h3>
+              <p className="text-sm">Try a different filter or create a new task</p>
+            </div>
+          ) : (
+            <>
+              {columns.map((col) => (
+                <Column
+                  key={col}
+                  columnId={col}
+                  tasks={getTasksByStatus(col)}
+                  onSelectTask={onSelectTask}
+                  onAddTask={handleAddTask}
+                  isActive={columns.indexOf(col) === activeCol}
+                />
+              ))}
+              <button
+                className="flex"
+                onClick={() => {
+                  setShowinput(true);
+                }}
+              >
+                + Add Column
+              </button>
+            </>
+          )}
         </div>
       </DragDropContext>
 


### PR DESCRIPTION
## Description

Adds a friendly empty state message when searching/filtering returns no tasks. Previously, the board just showed empty columns with no explanation.

## Changes

- Added isEmpty check to detect when all columns have no tasks after filtering
- Displays a search icon with helpful text No tasks found!
- Shows suggested actions: Try a different filter or create a new task

## Before
Empty columns with no explanation when search returns nothing.

## Fixes
Closes #273