### PR TITLE
fix: close task modal on Escape key

### DIFF
--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -34,6 +34,16 @@ const TaskModal = ({
   const [aiError, setAiError] = useState("");
   const { deleteTask } = useBoard();
 
+  useEffect(() => {
+    const handleKey = (e) => {
+      if(e.key === 'Escape') {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [])
+
   const handleGenerateAI = async () => {
     if (!form.title.trim()) {
       setAiError("Please enter a task title first.");


### PR DESCRIPTION
## Description

Adds Escape key support to close the task modal.

## Changes

- Added a keydown listener for the Escape key.

- Cleaned up the event listener when the component unmounts.

## Testing

- Verified that pressing Escape closes the task modal.

- Verified that the existing close button behavior still works.

- Verified that the application runs correctly locally.

Closes #280