### PR TITLE
feat: show DEV badge in navbar on development mode (#340)

### DIFF
--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -248,6 +248,12 @@ DevBoard
 beta
 </span>
 
+{import.meta.env.DEV && (
+<span className="text-xs bg-yellow-500 text-black px-1.5 py-0.5 rounded font-bold">
+DEV
+</span>
+)}
+
 
 </div>
 


### PR DESCRIPTION
## Summary
Adds a yellow "DEV" badge to the navbar that appears automatically in development mode and disappears in production.

## Changes
- Uses `import.meta.env.DEV` (Vite-provided) to detect development mode
- Renders a yellow "DEV" badge next to the "beta" label in the header
- No backend needed — Vite handles the environment detection

## Why
There was no way to tell if you're running in local dev or production. This badge provides a clear visual indicator that disappears automatically when built for production.

Closes #340