### PR TITLE
fix: restrict cors to allowed frontend origins

### DIFF
--- a/devboard/server/.env.example
+++ b/devboard/server/.env.example
@@ -2,3 +2,4 @@ PORT=5000
 MONGO_URI=mongodb://127.0.0.1:27017/devboard
 GEMINI_API_KEY=your_gemini_api_key_here
 JWT_SECRET=efd565ef0b6115333654465f356ea055b6f3ba81f31be3c4260407101cab128c
+FRONTEND_URL=http://localhost:5173

--- a/devboard/server/index.js
+++ b/devboard/server/index.js
@@ -9,6 +9,11 @@ const { Server } = require("socket.io");
 
 dotenv.config();
 
+const allowedOrigins = [
+  "http://localhost:5173",
+  process.env.FRONTEND_URL,
+].filter(Boolean);
+
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 100,
@@ -26,7 +31,20 @@ const io = new Server(server, {
 app.set("io", io);
 
 app.use(helmet());
-app.use(cors());
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
+  }),
+);
+
 app.use(express.json());
 app.use(limiter);
 


### PR DESCRIPTION
## What changed

- Restricted CORS to approved frontend origins
- Added `FRONTEND_URL` environment configuration
- Enabled credentials support for authenticated requests
- Preserved localhost development support

## Testing

Tested locally with:

- `http://localhost:5173` → allowed
- Production URL via `FRONTEND_URL` → allowed
- Unknown origin → rejected

## Related Issue

Closes #345