### PR TITLE
feat: add /api/health endpoint

### DIFF
--- a/devboard/server/index.js
+++ b/devboard/server/index.js
@@ -54,6 +54,17 @@ app.use("/api/tasks", require("./routes/tasks"));
 app.use("/api/github", require("./routes/github"));
 app.use("/api/ai", require("./routes/ai"));
 
+// Health check — no auth required
+app.get("/api/health", (req, res) => {
+  res.json({
+    status: "ok",
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+    mongodb:
+      mongoose.connection.readyState === 1 ? "connected" : "disconnected",
+  });
+});
+
 app.get("/", (req, res) => res.json({ message: "DevBoard API running 🚀" }));
 
 const onlineSockets = new Set();


### PR DESCRIPTION
## Description

Adds a public `GET /api/health` endpoint to report the server's health status.

The endpoint returns:
- Server status
- Process uptime
- Current timestamp
- MongoDB connection status

No authentication is required so deployment and monitoring services can use the endpoint.

## Testing

Tested locally with MongoDB running.

- `GET /api/health` → `200 OK`
- Verified `status`, `uptime`, `timestamp`, and MongoDB connection status
- Verified MongoDB reports `connected`

Closes #351