### PR TITLE
feat: add floating 404 animation and messages

### DIFF
--- a/devboard/client/src/pages/NotFound.jsx
+++ b/devboard/client/src/pages/NotFound.jsx
@@ -1,14 +1,35 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import {useEffect, useState} from "react";
 
 const NotFound = () => {
+    const messages = [
+    "Looks like this got deleted 💀",
+    "Lost in the backlog for fr fr 😭",
+    "This page ghosted us 👻",
+  ];
+
+  const [messageIndex, setMessageIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setMessageIndex((prev) => (prev + 1) % messages.length);
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   return (
     <div className="flex flex-col items-center justify-center h-screen bg-[var(--bg-primary)] text-center p-8">
-      <span className="text-6xl mb-4">🗂️</span>
-      <h2 className="text-3xl font-bold text-[#f0f0f0] mb-3">Lost in the backlog?</h2>
-      <p className="text-[#a0a0a5] mb-6 max-w-md text-lg">
-        The page you're looking for doesn't exist or has been moved.
-      </p>
+      <span className="text-6xl mb-4 animate-bounce">🗂️</span>
+      <h2 className="text-3xl font-bold text-[#f0f0f0] mb-3">
+          Lost in the backlog?
+   </h2>
+
+    <p>
+      {messages[messageIndex]}
+    </p>
+      
       <Link
         to="/"
         className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2.5 rounded-lg font-medium transition"


### PR DESCRIPTION
## Description

Closes #350

Added a floating/bouncing animation to the 404 page emoji and added rotating funny messages that change every 3 seconds.

### Changes
- Added floating animation to the 404 emoji
- Added 3 rotating messages
- Messages automatically change every 3 seconds
- No backend changes required

### Testing
- Tested locally
- Verified the emoji animation
- Verified messages rotate every 3 seconds


### Screenshots
<img width="579" height="433" alt="Screenshot 2026-08-21 173125" src="https://github.com/user-attachments/assets/056c5dcf-96c4-4486-9331-7def7cb4a37b" />
<img width="563" height="316" alt="Screenshot 2026-08-21 173144" src="https://github.com/user-attachments/assets/6fcae5d7-be77-4d91-b86c-10369cd1b764" />
<img width="535" height="382" alt="Screenshot 2026-08-21 173155" src="https://github.com/user-attachments/assets/c0987b06-d7b0-4395-bcfd-012bc60f93ab" />

