### PR TITLE
feat: add terms text to registration form

### DIFF
--- a/devboard/client/src/pages/Login.jsx
+++ b/devboard/client/src/pages/Login.jsx
@@ -168,6 +168,15 @@ const Login = () => {
             )}
           </button>
 
+          {isRegister && (
+            <p className="text-[10px] text-[#555] text-center leading-snug">
+              By creating an account you agree to our{' '}
+              <a href="#" className="text-purple-400 hover:underline">
+                Terms of Service
+              </a>
+            </p>
+          )}
+
           <button
             type="button"
             onClick={toggleMode}


### PR DESCRIPTION
## Description

Adds a Terms of Service notice below the registration button.

- Only shown in registration mode
- Uses existing styling conventions
- No backend changes
- No new dependencies

## Testing

Tested locally in both login and registration modes.

- Terms text appears when registering
- Terms text is hidden when logging in

Closes #357