### PR TITLE
feat: show live GitHub star count in navbar

### DIFF
--- a/devboard/client/src/hooks/useGithubStars.js
+++ b/devboard/client/src/hooks/useGithubStars.js
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+import axios from "axios";
+
+/**
+ * Fetches the GitHub star count for a given repo.
+ *
+ * @param {string} repo - "owner/repo" string (defaults to anoopcodehack/DevBoard)
+ * @returns {{ stars: number|null, loading: boolean }}
+ */
+export const useGithubStars = (repo = "anoopcodehack/DevBoard") => {
+  const [stars, setStars] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchStars = async () => {
+      try {
+        const { data } = await axios.get(
+          `https://api.github.com/repos/${repo}`
+        );
+        if (!cancelled) {
+          setStars(data.stargazers_count);
+        }
+      } catch (err) {
+        console.warn("useGithubStars: failed to fetch star count", err);
+        // Leave stars as null — caller renders a safe fallback
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchStars();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repo]);
+
+  return { stars, loading };
+};

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -4,567 +4,225 @@ import PomodoroTimer from "../components/Pomodoro/PomodoroTimer";
 import TaskModal from "../components/Task/TaskModal";
 import Heatmap from "../components/Heatmap/Heatmap";
 import { useBoard } from "../context/BoardContext";
+import { useGithubStars } from "../hooks/useGithubStars";
+
+const formatStars = (n) => {
+  if (n === null || n === undefined) return null;
+  if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return String(n);
+};
 
 const Dashboard = () => {
+  const {
+    user,
+    logout,
+    updateTask,
+    deleteTask,
+    loading,
+    searchQuery,
+    setSearchQuery,
+    tasks,
+    addTask,
+    activeTag,
+    setActiveTag,
+  } = useBoard();
+  const { stars, loading: starsLoading } = useGithubStars();
+  useEffect(() => {
+    document.title = "Dashboard — DevBoard";
+  }, []);
+  const [selectedTask, setSelectedTask] = useState(null);
+  const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
+  const [showTop, setShowTop] = useState(false);
 
-const {
-user,
-onlineUsers,
-logout,
-fetchTasks,
-error,
-updateTask,
-deleteTask,
-loading,
-searchQuery,
-setSearchQuery,
-tasks,
-addTask,
-activeTag,
-setActiveTag,
-} = useBoard();
+  useEffect(() => {
+    const handleScroll = (event) => {
+      let scrollTop = 0;
+      if (event.target === document || event.target === window) {
+        scrollTop = window.scrollY;
+      } else if (event.target) {
+        scrollTop = event.target.scrollTop;
+      }
+      setShowTop(scrollTop > 300);
+    };
 
-const inProgressCount = tasks.filter(
-  (task) => task.status === "inprogress"
-).length;
+    window.addEventListener("scroll", handleScroll, true);
+    return () => window.removeEventListener("scroll", handleScroll, true);
+  }, []);
 
-const doneCount = tasks.filter((task) => task.status === "done").length;
-const donePercent =
-  tasks.length === 0 ? 0 : Math.round((doneCount / tasks.length) * 100);
+  if (loading) {
+    return (
+      <div className="flex gap-4 p-4">
+        {[1, 2, 3, 4].map((col) => (
+          <div key={col} className="flex flex-col w-56 gap-2">
+            {[1, 2, 3].map((card) => (
+              <div
+                key={card}
+                className="animate-pulse bg-[#2a2a2f] rounded-lg h-20 w-full"
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  }
 
-useEffect(() => {
-document.title = inProgressCount > 0
-  ? `(${inProgressCount}) DevBoard`
-  : "DevBoard";
-}, [inProgressCount]);
-
-const [selectedTask, setSelectedTask] = useState(null);
-const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
-const [showScrollTop, setShowScrollTop] = useState(false);
-const [activeCol, setActiveCol] = useState(0);
-const [assigneeFilter, setAssigneeFilter] = useState("all");
-const [filter, setFilter] = useState("all");
-
-const assignees = [
-  ...new Set(tasks.map((task) => task.assignee?.name).filter(Boolean)),
-].sort();
-
-const filteredTasks = tasks.filter(
-  (task) =>
-    assigneeFilter === "all" || task.assignee?.name === assigneeFilter,
-);
-
-useEffect(() => {
-const handleScroll = () => {
-setShowScrollTop(window.scrollY > 300);
-};
-window.addEventListener("scroll", handleScroll);
-return () => {
-window.removeEventListener("scroll", handleScroll);
-};
-}, []);
-
-useEffect(() => {
-  const handler = (e) => {
-    if (e.key === "ArrowRight") {
-      setActiveCol((prev) => Math.min(prev + 1, 3));
-    }
-    if (e.key === "ArrowLeft") {
-      setActiveCol((prev) => Math.max(prev - 1, 0));
+  const handleLogout = () => {
+    if (window.confirm("Are you sure you want to logout?")) {
+      logout();
     }
   };
-  window.addEventListener("keydown", handler);
-  return () => {
-    window.removeEventListener("keydown", handler);
+
+  const handleClearDone = async () => {
+    if (window.confirm("Clear all done tasks?")) {
+      const doneTasks = tasks.filter((t) => t.status === "done");
+      await Promise.all(doneTasks.map((t) => deleteTask(t._id)));
+    }
   };
-}, []);
 
-if (loading) {
-return (
-<div className="flex items-center justify-center min-h-screen">
-Loading...
-</div>
-);
-}
+  const handleSessionComplete = async () => {
+    if (selectedTask) {
+      await updateTask(selectedTask._id, {
+        pomodoroCount: (selectedTask.pomodoroCount || 0) + 1,
+      });
+    }
+  };
 
-if (error) {
   return (
-    <div>
-      <p>{error}</p>
-      <button onClick={fetchTasks}>Try again</button>
+    <div className="flex flex-col h-screen bg-[var(--bg-primary)]">
+      {/* Top Navbar */}
+      <div className="flex flex-col gap-3 px-5 py-3 bg-[var(--bg-card)] border-b border-[var(--border-primary)] md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-lg">🗂️</span>
+          <span className="font-semibold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            DevBoard
+          </span>
+          <span className="text-xs bg-purple-600/20 text-purple-400 px-2 py-0.5 rounded-full ml-1">
+            beta
+          </span>
+          <span className="text-xs text-[#666] ml-2">
+            {tasks.length} {tasks.length === 1 ? "task" : "tasks"}
+          </span>
+          {activeTag && (
+            <button
+              onClick={() => setActiveTag(null)}
+              className="text-xs bg-purple-600/30 text-purple-300 px-2 py-0.5 rounded-full flex items-center gap-1 hover:bg-purple-600/40 transition"
+            >
+              #{activeTag} <span aria-hidden>✕</span>
+            </button>
+          )}
+        </div>
+        <div className="flex-1 w-full max-w-xl md:px-6">
+          <label className="relative block">
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search tasks by title or tag..."
+              className="w-full bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded-xl px-4 py-2.5 text-sm text-[#f0f0f0] placeholder-[#555] focus:outline-none focus:border-purple-500 focus:ring-2 focus:ring-purple-500/15 transition"
+            />
+          </label>
+        </div>
+        <div className="flex items-center gap-3">
+          <a
+            href="https://github.com/anoopcodehack/DevBoard"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[#666] hover:text-white transition px-3 py-1.5 border border-[#2a2a2f] rounded-lg"
+          >
+            {!starsLoading && stars !== null
+              ? `⭐ ${formatStars(stars)} Star on GitHub`
+              : "⭐ Star on GitHub"}
+          </a>
+          <span className="text-xs text-[#666]">👋 {user?.name}</span>
+          <button
+            onClick={handleClearDone}
+            className="text-xs text-[#666] hover:text-red-400 transition px-3 py-1.5 border border-[#2a2a2f] rounded-lg"
+          >
+            🗑️ Clear Done
+          </button>
+          <button
+            onClick={handleLogout}
+            className="text-xs text-[#666] hover:text-[#aaa] transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg"
+          >
+            Logout
+          </button>
+        </div>
+      </div>
+
+      {/* Activity Heatmap */}
+      <Heatmap />
+
+      {/* Pomodoro Bar */}
+      <PomodoroTimer
+        activeTaskTitle={selectedTask?.title}
+        onSessionComplete={handleSessionComplete}
+      />
+      {/* Kanban Board */}
+      <div className="flex-1 overflow-hidden">
+        {tasks.length === 0 ? (
+          <div className="flex-1 h-full flex flex-col items-center justify-center text-center p-8">
+            <span className="text-6xl mb-4">👋</span>
+            <h2 className="text-2xl font-semibold text-[#f0f0f0] mb-2">
+              Welcome to your board!
+            </h2>
+            <p className="text-[#a0a0a5] mb-6 max-w-md">
+              You don't have any tasks yet. Click + Add card to create your
+              first one.
+            </p>
+            <button
+              onClick={() => setIsCreatingFirstTask(true)}
+              className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2.5 rounded-lg font-medium transition"
+            >
+              + Add your first card
+            </button>
+          </div>
+        ) : (
+          <KanbanBoard onSelectTask={setSelectedTask} />
+        )}
+      </div>
+      {/* Task Edit Modal */}
+      {selectedTask && (
+        <TaskModal
+          mode="edit"
+          task={selectedTask}
+          onClose={() => setSelectedTask(null)}
+          onSave={async (data) => {
+            await updateTask(selectedTask._id, data);
+            setSelectedTask(null);
+          }}
+          updateTask={updateTask}
+        />
+      )}
+      {/* Create First Task Modal */}
+      {isCreatingFirstTask && (
+        <TaskModal
+          mode="create"
+          defaultStatus="backlog"
+          onClose={() => setIsCreatingFirstTask(false)}
+          onSave={async (data) => {
+            await addTask(data);
+            setIsCreatingFirstTask(false);
+          }}
+        />
+      )}
+      {showTop && (
+        <button
+          onClick={() => {
+            window.scrollTo({ top: 0, behavior: "smooth" });
+            const scrollContainers = document.querySelectorAll(
+              ".overflow-y-auto, .overflow-y-scroll"
+            );
+            scrollContainers.forEach((container) => {
+              container.scrollTo({ top: 0, behavior: "smooth" });
+            });
+          }}
+          className="fixed bottom-6 right-6 bg-purple-600 hover:bg-purple-500 text-white rounded-full w-10 h-10 text-lg shadow-lg transition z-50 flex items-center justify-center"
+          aria-label="Scroll to top"
+        >
+          ⬆️
+        </button>
+      )}
     </div>
   );
-}
-
-const handleLogout = () => {
-
-if (window.confirm("Are you sure you want to logout?")) {
-
-logout();
-
-}
-
 };
-
-const handleClearDone = async () => {
-
-if (window.confirm("Clear all done tasks?")) {
-
-
-const doneTasks =
-tasks.filter(
-(t) => t.status === "done"
-);
-
-
-await Promise.all(
-doneTasks.map(
-(t) => deleteTask(t._id)
-)
-);
-
-
-}
-
-};
-
-const handleSessionComplete = async () => {
-
-
-if (selectedTask) {
-
-
-await updateTask(
-selectedTask._id,
-{
-pomodoroCount:
-(selectedTask.pomodoroCount || 0) + 1,
-}
-);
-
-
-}
-
-
-};
-
-return (
-
-<div className="min-h-screen flex flex-col">
-
-
-
-{/* Top Navbar */}
-
-<header className="flex items-center justify-between p-4 border-b border-[var(--border-primary)]">
-
-
-<div className="flex items-center gap-3">
-
-
-<span className="text-2xl">
-🗂️
-</span>
-
-
-<div>
-
-<h1 className="text-xl font-bold text-[#f0f0f0]">
-DevBoard
-</h1>
-
-
-<span className="text-xs text-purple-400">
-beta
-</span>
-
-{import.meta.env.DEV && (
-<span className="text-xs bg-yellow-500 text-black px-1.5 py-0.5 rounded font-bold">
-DEV
-</span>
-)}
-
-
-</div>
-
-
-</div>
-
-
-
-
-
-
-
-<div className="flex items-center gap-4">
-
-
-<span className="text-sm text-[#a0a0a5]">
-🟢 {onlineUsers} online
-</span>
-
-
-<span className="text-sm text-[#a0a0a5]">
-
-{filteredTasks.length}
-
-{filteredTasks.length === 1 ? " task" : " tasks"}
-
-</span>
-
-
-<span className="text-sm text-green-400" title="Percentage of tasks completed">
-📊 {donePercent}% done
-</span>
-
-
-
-
-
-{activeTag && (
-
-<button
-
-onClick={() => setActiveTag(null)}
-
-className="text-xs bg-purple-600/30 text-purple-300 px-2 py-0.5 rounded-full flex items-center gap-1 hover:bg-purple-600/40 transition"
-
->
-
-#{activeTag} ✕
-
-</button>
-
-)}
-
-<select
-  value={assigneeFilter}
-  onChange={(e) => setAssigneeFilter(e.target.value)}
-  aria-label="Filter tasks by assignee"
-  className="bg-[#2a2a2f] text-[#888] text-xs rounded-lg px-2 py-1.5 border border-[#333]"
->
-  <option value="all">All Members</option>
-  {assignees.map((name) => (
-    <option key={name} value={name}>
-      {name}
-    </option>
-  ))}
-</select>
-
-<select
-  value={filter}
-  onChange={(e) => setFilter(e.target.value)}
-  aria-label="Filter tasks by priority"
-  className="bg-[#2a2a2f] text-[#888] text-xs rounded-lg px-2 py-1.5 border border-[#333]"
->
-  <option value="all">All Priority</option>
-  <option value="high">🔴 High</option>
-  <option value="medium">🟡 Medium</option>
-  <option value="low">🟢 Low</option>
-</select>
-
-
-<input
-
-type="text"
-
-value={searchQuery}
-
-onChange={(e)=>setSearchQuery(e.target.value)}
-
-placeholder="Search tasks by title or tag..."
-
-className="bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded-xl px-4 py-2 text-sm"
-
- />
-
-
-
-
-
-<button>
-⭐ Star on GitHub
-</button>
-
-
-<span>
-👋 {user?.name}
-</span>
-
-
-<button onClick={handleClearDone}>
-🗑️ Clear Done
-</button>
-
-
-<button onClick={handleLogout}>
-Logout
-</button>
-
-
-
-</div>
-
-
-
-</header>
-
-
-
-
-
-
-
-
-
-{/* Activity Heatmap */}
-
-<Heatmap />
-
-
-
-
-
-
-
-{/* Pomodoro */}
-
-<PomodoroTimer
-
-activeTaskTitle={selectedTask?.title}
-
-onSessionComplete={handleSessionComplete}
-
-/>
-
-
-
-
-
-
-
-
-
-{/* Priority Breakdown Summary */}
-      {tasks.length > 0 && (() => {
-        const high = filteredTasks.filter(t => t.priority === 'high').length;
-        const medium = filteredTasks.filter(t => t.priority === 'medium').length;
-        const low = filteredTasks.filter(t => t.priority === 'low').length;
-        return (
-          <div
-            className="flex items-center gap-4 px-4 py-2 text-sm"
-            style={{ background: '#1e1e22', borderBottom: '1px solid #2a2a2f' }}
-          >
-            <span style={{ color: '#a0a0a5' }}>📊 Priority:</span>
-            <span style={{ color: '#f87171' }}>🔴 {high} high</span>
-            <span style={{ color: '#facc15' }}>🟡 {medium} medium</span>
-            <span style={{ color: '#4ade80' }}>🟢 {low} low</span>
-          </div>
-        );
-      })()}
-
-      {/* Board */}
-
-<div className="flex-1 overflow-hidden">
-
-
-{tasks.length === 0 ? (
-
-
-<div className="flex flex-col items-center justify-center text-center p-8">
-
-
-<span className="text-6xl mb-4">
-👋
-</span>
-
-
-
-<h2 className="text-2xl font-semibold text-[#f0f0f0] mb-2">
-
-Welcome to your board!
-
-</h2>
-
-
-
-<p className="text-[#a0a0a5] mb-6 max-w-md">
-
-You don't have any tasks yet. Click + Add card to create your first one.
-
-</p>
-
-
-
-
-<button
-
-onClick={() => setIsCreatingFirstTask(true)}
-
-className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2.5 rounded-lg"
-
->
-
-+ Add your first card
-
-</button>
-
-
-</div>
-
-
-
-) : (
-
-
-
-<KanbanBoard 
-tasks={filteredTasks}
-onSelectTask={setSelectedTask}
-activeCol={activeCol}
-priorityFilter={filter}
-/>
-
-
-
-)}
-
-
-</div>
-
-
-
-
-
-
-
-
-
-{/* Edit Modal */}
-
-{selectedTask && (
-
-
-<TaskModal
-
-mode="edit"
-
-task={selectedTask}
-
-onClose={() => setSelectedTask(null)}
-
-
-onSave={async(data)=>{
-
-await updateTask(
-selectedTask._id,
-data
-);
-
-
-setSelectedTask(null);
-
-}}
-
-
-updateTask={updateTask}
-
-/>
-
-
-)}
-
-
-
-
-
-
-
-
-
-{/* Create Modal */}
-
-
-{isCreatingFirstTask && (
-
-
-<TaskModal
-
-mode="create"
-
-defaultStatus="backlog"
-
-
-onClose={() =>
-setIsCreatingFirstTask(false)
-}
-
-
-onSave={async(data)=>{
-
-
-await addTask(data);
-
-
-setIsCreatingFirstTask(false);
-
-
-}}
-
-
-/>
-
-
-)}
-
-
-
-
-
-
-
-
-
-{/* Scroll To Top Button */}
-
-
-{showScrollTop && (
-
-<button
-
-onClick={() =>
-
-window.scrollTo({
-
-top:0,
-
-behavior:"smooth"
-
-})
-
-}
-
-className="fixed bottom-6 right-6 bg-purple-600 hover:bg-purple-700 text-white w-12 h-12 rounded-full shadow-lg flex items-center justify-center text-xl transition"
-
->
-
-↑
-
-</button>
-
-
-)}
-
-
-
-
-
-</div>
-
-
-);
-
-};
-
-
 export default Dashboard;


### PR DESCRIPTION
Closes #370 

## What this does
Replaces the dead "⭐ Star on GitHub" button in the navbar (it had no
href/onClick) with a real link to the repo that also shows the current
star count.

Before: static text, not clickable
After:  clickable link → "⭐ 123 Star on GitHub" (formatted as "1.2k" for ≥1000)

Note: the count is fetched once on page load, not polled — "live" here
means "current as of this page load," not continuously updating.

## Implementation
Followed the existing pattern in `useSuggestTags.jsx` of keeping fetch
logic in a dedicated hook rather than inline in the component.

**New — `src/hooks/useGithubStars.js`**
- Takes an optional `repo` param (default `"anoopcodehack/DevBoard"`)
- Fetches `stargazers_count` via `axios` + `async/await` on mount
- Swallows errors (including GitHub's unauthenticated 403 rate limit) —
  logs a `console.warn`, leaves `stars` as `null`, never throws

**Modified — `src/pages/Dashboard.jsx`**
- Uses `useGithubStars()`, adds a small `formatStars` helper
- Swaps the `<button>` for an `<a>` (`target="_blank" rel="noopener noreferrer"`)
- Falls back to plain "⭐ Star on GitHub" while loading or on fetch failure —
  no layout shift
- Reuses the existing Tailwind classes from the sibling "🗑️ Clear Done"
  button — no new styles

## Testing done
- `npm run dev` in `client/`, confirmed the link renders immediately and
  updates once the count loads
- Confirmed it's clickable and opens the repo in a new tab
- Blocked `api.github.com` in devtools to simulate a rate limit / offline
  case — button correctly falls back to plain text, no console errors,
  no crash

## Checklist
- [x] My code follows the project's style guidelines
- [x] I tested my changes locally
- [ ] I updated the README (not needed — no setup/usage change)
- [x] My commit messages are clear and follow the conventional commit format