### PR TITLE
docs: add Windows setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,41 @@ No local MongoDB? Use a free [MongoDB Atlas](https://www.mongodb.com/cloud/atlas
 > ```
 > You'll only need the full backend setup if your issue touches API routes, auth, or data persistence.
 
+## 🪟 Windows Setup
+
+If you're on Windows, use Git Bash or WSL for the best experience.
+
+### Clone
+
+```bash
+git clone https://github.com/YOUR_USERNAME/devboard.git
+cd devboard
+```
+
+### Install dependencies
+
+```bash
+npm run install:all
+```
+
+### Copy environment file
+
+```bash
+cp .env.example server/.env
+```
+
+### Run
+
+```bash
+npm run dev
+```
+
+Common Windows issues:
+
+- Use Git Bash, not CMD.
+- If port 5000 is busy, run `netstat -ano | findstr :5000`.
+- If you run into MongoDB path issues, use MongoDB Atlas instead.
+
 ## 📐 Code Style
 
 To keep the codebase consistent, please follow these conventions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ If you're on Windows, use Git Bash or WSL for the best experience.
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/devboard.git
-cd devboard
+cd devboard/devboard
 ```
 
 ### Install dependencies
@@ -94,7 +94,7 @@ npm run install:all
 ### Copy environment file
 
 ```bash
-cp .env.example server/.env
+cp server/.env.example server/.env
 ```
 
 ### Run


### PR DESCRIPTION
## Summary

- Add Windows setup instructions to `CONTRIBUTING.md`
- Recommend Git Bash or WSL for Windows users
- Document clone, dependency installation, environment setup, and run steps
- Add common Windows troubleshooting notes
- Fix the nested project path and `.env.example` path after testing the setup locally

## Testing

Tested the instructions on Windows using Git Bash:

- `npm run install:all`
- `cp server/.env.example server/.env`
- `npm run dev`
- Frontend loaded successfully at `http://localhost:5173`
- Backend started successfully on port `5000`
- MongoDB connection verified

Closes #377