### PR TITLE
feat: add memory usage stats to /api/health endpoint

### DIFF
--- a/devboard/server/index.js
+++ b/devboard/server/index.js
@@ -64,12 +64,18 @@ app.use("/api/ai", require("./routes/ai"));
 
 // Health check — no auth required
 app.get("/api/health", (req, res) => {
+  const mem = process.memoryUsage();
   res.json({
     status: "ok",
     uptime: process.uptime(),
     timestamp: new Date().toISOString(),
     mongodb:
       mongoose.connection.readyState === 1 ? "connected" : "disconnected",
+    memory: {
+      heapUsed: `${Math.round(mem.heapUsed / 1024 / 1024)}MB`,
+      heapTotal: `${Math.round(mem.heapTotal / 1024 / 1024)}MB`,
+      rss: `${Math.round(mem.rss / 1024 / 1024)}MB`,
+    },
   });
 });
 


### PR DESCRIPTION
## Summary
- Extends `GET /api/health` with Node.js process memory usage (`heapUsed`, `heapTotal`, `rss`) reported in MB
- Uses built-in `process.memoryUsage()` — no new dependencies
- Helps developers monitor server resource usage during local development and debugging

Closes #390

## Test plan
- [ ] Start the server (`cd server && npm run dev`)
- [ ] Request `GET http://localhost:5000/api/health`
- [ ] Confirm response still includes `status`, `uptime`, `timestamp`, and `mongodb`
- [ ] Confirm `memory` object is present with `heapUsed`, `heapTotal`, and `rss` as MB strings (e.g. `"24MB"`)