### PR TITLE
feat: add color label picker to task cards

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -71,6 +71,7 @@ const TaskCard = ({ task, index, onSelect }) => {
         description: task.description,
         status: task.status,
         priority: task.priority,
+        labelColor: task.labelColor,
         tags: task.tags,
         snippets: task.snippets?.map(({ language, code }) => ({
           language,
@@ -123,6 +124,12 @@ const TaskCard = ({ task, index, onSelect }) => {
           {...provided.dragHandleProps}
           onClick={() => onSelect(task)}
           onContextMenu={handleContextMenu}
+          style={{
+            ...provided.draggableProps.style,
+            ...(task.labelColor
+              ? { borderLeft: `3px solid ${task.labelColor}` }
+              : {}),
+          }}
           className={`group bg-[var(--bg-card)] border rounded-lg p-3 cursor-pointer transition-all
             hover:shadow-lg ${GLOW[task.priority] || "hover:shadow-purple-500/20"}
             ${snapshot.isDragging ? "border-purple-500 shadow-lg shadow-purple-500/10" : isOverdue

--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -1,6 +1,16 @@
 import React, { useState, useEffect } from "react";
 import { useBoard } from "../../context/BoardContext";
 
+const COLORS = [
+  "#7F77DD",
+  "#E85D75",
+  "#27AE60",
+  "#F39C12",
+  "#2980B9",
+  "#E74C3C",
+  "",
+];
+
 const TaskModal = ({
   task,
   mode = "create",
@@ -14,6 +24,7 @@ const TaskModal = ({
     description: task?.description || "",
     status: task?.status || defaultStatus,
     priority: task?.priority || "medium",
+    labelColor: task?.labelColor || "",
     tags: task?.tags?.join(", ") || "",
     githubIssueUrl: task?.githubIssueUrl || "",
     githubIssueNumber: task?.githubIssueNumber || "",
@@ -219,6 +230,26 @@ const TaskModal = ({
               <option value="medium">Medium Priority</option>
               <option value="high">High Priority</option>
             </select>
+          </div>
+
+          <div>
+            <label className="text-xs text-[#888] mb-1.5 block">Label color</label>
+            <div className="flex items-center gap-2">
+              {COLORS.map((color) => (
+                <button
+                  key={color || "none"}
+                  type="button"
+                  title={color || "No color"}
+                  onClick={() => setForm({ ...form, labelColor: color })}
+                  style={{ background: color || "transparent" }}
+                  className={`w-5 h-5 rounded-full border-2 ${
+                    form.labelColor === color
+                      ? "border-white"
+                      : "border-[#444]"
+                  }`}
+                />
+              ))}
+            </div>
           </div>
 
           <input

--- a/devboard/server/models/Task.js
+++ b/devboard/server/models/Task.js
@@ -19,6 +19,7 @@ const taskSchema = new mongoose.Schema(
       enum: ["low", "medium", "high"],
       default: "medium",
     },
+    labelColor: { type: String, default: "" },
     tags: [{ type: String }],
     snippets: [snippetSchema],
     githubIssueUrl: { type: String, default: "" },


### PR DESCRIPTION
## Summary
- Adds a label color picker in the task create/edit modal
- Persists `labelColor` on the Task model
- Shows the selected color as a left border on task cards
- Includes a “no color” option and preserves color when duplicating a task

Closes #389

## Test plan
- [ ] Create a task, pick a label color, save — card shows colored left border
- [ ] Edit the task and change color — border updates
- [ ] Select the empty/clear swatch — border is removed
- [ ] Duplicate a colored task — new card keeps the same label color
- [ ] Confirm create/edit still works with no color selected