### PR TITLE
feat: add Print Board button to dashboard

### DIFF
--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -186,7 +186,7 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFi
       )}
 
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="flex flex-col md:flex-row gap-4 p-4 overflow-x-hidden md:overflow-x-auto overflow-y-auto h-full">
+        <div className="board flex flex-col md:flex-row gap-4 p-4 overflow-x-hidden md:overflow-x-auto overflow-y-auto h-full">
           {isEmpty ? (
             <div className="flex flex-col items-center justify-center w-full h-64 text-gray-500">
               <span className="text-4xl mb-4">🔍</span>
@@ -206,7 +206,7 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFi
                 />
               ))}
               <button
-                className="flex"
+                className="flex no-print"
                 onClick={() => {
                   setShowinput(true);
                 }}

--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -130,7 +130,7 @@ const TaskCard = ({ task, index, onSelect }) => {
               ? { borderLeft: `3px solid ${task.labelColor}` }
               : {}),
           }}
-          className={`group bg-[var(--bg-card)] border rounded-lg p-3 cursor-pointer transition-all
+          className={`card group bg-[var(--bg-card)] border rounded-lg p-3 cursor-pointer transition-all
             hover:shadow-lg ${GLOW[task.priority] || "hover:shadow-purple-500/20"}
             ${snapshot.isDragging ? "border-purple-500 shadow-lg shadow-purple-500/10" : isOverdue
               ? "border-red-500 border-l-4 hover:border-red-400" : "border-[var(--border-primary)] hover:border-[#444]"}`}

--- a/devboard/client/src/index.css
+++ b/devboard/client/src/index.css
@@ -24,3 +24,19 @@ body {
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: var(--bg-card); }
 ::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+
+  .board {
+    display: block !important;
+    overflow: visible !important;
+    height: auto !important;
+  }
+
+  .card {
+    break-inside: avoid;
+  }
+}

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -110,6 +110,10 @@ const Dashboard = () => {
     localStorage.setItem("search_history", JSON.stringify(updated));
   };
 
+  const handlePrint = () => {
+    window.print();
+  };
+
   return (
     <div className="flex flex-col h-screen bg-[var(--bg-primary)]">
       {/* Top Navbar */}
@@ -134,7 +138,7 @@ const Dashboard = () => {
             </button>
           )}
         </div>
-        <div className="flex-1 w-full max-w-xl md:px-6">
+        <div className="flex-1 w-full max-w-xl md:px-6 no-print">
           <label className="relative block">
             <input
               type="text"
@@ -163,7 +167,14 @@ const Dashboard = () => {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 no-print">
+          <button
+            type="button"
+            onClick={handlePrint}
+            className="text-xs text-[#666] hover:text-white transition px-3 py-1.5 border border-[#2a2a2f] rounded-lg"
+          >
+            🖨️ Print
+          </button>
           <a
             href="https://github.com/anoopcodehack/DevBoard"
             target="_blank"
@@ -191,13 +202,17 @@ const Dashboard = () => {
       </div>
 
       {/* Activity Heatmap */}
-      <Heatmap />
+      <div className="no-print">
+        <Heatmap />
+      </div>
 
       {/* Pomodoro Bar */}
-      <PomodoroTimer
-        activeTaskTitle={selectedTask?.title}
-        onSessionComplete={handleSessionComplete}
-      />
+      <div className="no-print">
+        <PomodoroTimer
+          activeTaskTitle={selectedTask?.title}
+          onSessionComplete={handleSessionComplete}
+        />
+      </div>
       {/* Kanban Board */}
       <div className="flex-1 overflow-hidden">
         {tasks.length === 0 ? (
@@ -257,7 +272,7 @@ const Dashboard = () => {
               container.scrollTo({ top: 0, behavior: "smooth" });
             });
           }}
-          className="fixed bottom-6 right-6 bg-purple-600 hover:bg-purple-500 text-white rounded-full w-10 h-10 text-lg shadow-lg transition z-50 flex items-center justify-center"
+          className="no-print fixed bottom-6 right-6 bg-purple-600 hover:bg-purple-500 text-white rounded-full w-10 h-10 text-lg shadow-lg transition z-50 flex items-center justify-center"
           aria-label="Scroll to top"
         >
           ⬆️


### PR DESCRIPTION
## Summary
- Adds a **🖨️ Print** button in the dashboard navbar that opens the browser print dialog via `window.print()`
- Adds print-only CSS in `index.css` to hide chrome UI (`.no-print`) and keep task cards from splitting across pages
- Marks the kanban container as `.board` and task cards as `.card` so print styles apply

Closes #388

## Test plan
- [ ] Open the dashboard with tasks in multiple columns
- [ ] Click **🖨️ Print** — browser print preview opens
- [ ] Confirm search, heatmap, pomodoro, and action buttons are hidden in print preview
- [ ] Confirm board columns/tasks are visible and cards are not awkwardly split across pages
- [ ] Cancel print — app UI remains unchanged