### PR TITLE
feat: add fullscreen focus toggle to dashboard navbar

### DIFF
--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -33,6 +33,7 @@ const Dashboard = () => {
   const [selectedTask, setSelectedTask] = useState(null);
   const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
   const [showTop, setShowTop] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const [searchHistory, setSearchHistory] = useState(() => {
     try {
       const saved = JSON.parse(localStorage.getItem("search_history") || "[]");
@@ -56,6 +57,28 @@ const Dashboard = () => {
     window.addEventListener("scroll", handleScroll, true);
     return () => window.removeEventListener("scroll", handleScroll, true);
   }, []);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(Boolean(document.fullscreenElement));
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  const handleFullscreen = async () => {
+    try {
+      if (!document.fullscreenElement) {
+        await document.documentElement.requestFullscreen();
+      } else {
+        await document.exitFullscreen();
+      }
+    } catch (error) {
+      console.warn("Unable to toggle fullscreen mode:", error);
+    }
+  };
 
   if (loading) {
     return (
@@ -186,6 +209,15 @@ const Dashboard = () => {
               : "⭐ Star on GitHub"}
           </a>
           <span className="text-xs text-[#666]">👋 {user?.name}</span>
+          {document.fullscreenEnabled && (
+            <button
+              onClick={handleFullscreen}
+              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+              className="text-xs text-[#666] hover:text-red-400 transition px-3 py-1.5 border border-[#2a2a2f] rounded-lg"
+            >
+              {isFullscreen ? "⊠ Exit" : "⛶ Focus"}
+            </button>
+          )}
           <button
             onClick={handleClearDone}
             className="text-xs text-[#666] hover:text-red-400 transition px-3 py-1.5 border border-[#2a2a2f] rounded-lg"


### PR DESCRIPTION
## What changed

- Added a fullscreen toggle in the Dashboard navbar for a distraction-free board view.
- Syncs its label and aria-label with the browser’s native `fullscreenchange` event, including Esc exits.
- Hides the control where the Fullscreen API is unavailable.
- Kept the change frontend-only with no new dependencies.

## Why

This gives users a quick way to focus on their board without browser chrome or other distractions.

## Testing

- Ran `npm install`
- Ran `npm run build`

Closes #379 

## Checklist

- [x] Code follows the project style guidelines.
- [x] Change is scoped to the assigned frontend feature.
- [x] No README update is needed.
- [x] Commit title follows Conventional Commits.