### PR TITLE
fix: autofocus task title input when modal opens

### DIFF
--- a/devboard/client/src/components/Task/TaskModal.jsx
+++ b/devboard/client/src/components/Task/TaskModal.jsx
@@ -179,6 +179,7 @@ const TaskModal = ({
 
         <div className="p-5 flex flex-col gap-3 max-h-[70vh] overflow-y-auto">
           <input
+            autoFocus
             type="text"
             placeholder="Task title *"
             maxLength={100}


### PR DESCRIPTION
Closes #395

The task modal opened without focus, so you always had to click into the title field before you could type. Now the title input gets focus when the modal mounts.

One line in `client/src/components/Task/TaskModal.jsx`, works the same for creating and editing a task.

### Checklist
- [x] My code follows the project's style guidelines
- [x] I tested my changes locally (`npm run build` in `client` passes)
- [x] No README changes needed, setup and usage are unchanged
- [x] Commit message follows conventional commits