### PR TITLE
feat: highlight matching text on task cards while searching

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -29,6 +29,32 @@ const TAG_COLORS = [
 const getTagColor = (tag) =>
   TAG_COLORS[tag.charCodeAt(0) % TAG_COLORS.length];
 
+// Search terms are raw user input, so they have to be escaped before they can
+// be used as a pattern — searching for "(" would otherwise throw.
+const escapeRegExp = (text) => text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Wrap every occurrence of the active search term in a <mark> so it is visible
+// on the card itself why it survived the filter.
+const highlightMatch = (text, query) => {
+  const term = query?.trim();
+  if (!term || !text) return text;
+
+  const parts = String(text).split(new RegExp(`(${escapeRegExp(term)})`, "gi"));
+
+  return parts.map((part, i) =>
+    part.toLowerCase() === term.toLowerCase() ? (
+      <mark
+        key={i}
+        className="bg-purple-500/30 text-purple-300 rounded px-0.5"
+      >
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+};
+
 const timeAgo = (date) => {
   const diff = Date.now() - new Date(date);
   const mins = Math.floor(diff / 60000);
@@ -46,7 +72,7 @@ const TaskCard = ({ task, index, onSelect }) => {
   const [copied, setCopied] = useState(false);
   const [contextMenu, setContextMenu] = useState(null);
   const cardRef = useRef(null);
-  const { activeTag, setActiveTag, updateTask, deleteTask, addTask } = useBoard();
+  const { activeTag, setActiveTag, updateTask, deleteTask, addTask, searchQuery } = useBoard();
   const { suggestedTags, loadingTags, handleSuggestTags, handleAddTag } = useSuggestTags(task, selectedSnippet, updateTask);
 
   const handleCopy = (e) => {
@@ -138,7 +164,7 @@ const TaskCard = ({ task, index, onSelect }) => {
           {/* Title */}
           <div className="flex items-start justify-between gap-2 mb-2">
             <p className="text-sm font-medium text-[#f0f0f0] leading-snug">
-              {task.title}
+              {highlightMatch(task.title, searchQuery)}
             </p>
 
             <button
@@ -288,7 +314,10 @@ const TaskCard = ({ task, index, onSelect }) => {
                       : "hover:brightness-125"
                     }`}
                 >
-                  {t.length > 15 ? t.slice(0, 15) + "..." : t}
+                  {highlightMatch(
+                    t.length > 15 ? t.slice(0, 15) + "..." : t,
+                    searchQuery
+                  )}
                 </span>
               );
             })}


### PR DESCRIPTION
Closes #383

Search already filtered the board, but nothing on the card showed you *why* it matched. This wraps every occurrence of the search term in a `<mark>`.

### What changed

`client/src/components/Board/TaskCard.jsx`:

* `highlightMatch()` as a module level helper, next to the existing `getTagColor` and `timeAgo`
* `searchQuery` pulled from `BoardContext`, it was already exported
* Applied to the card title and to the tags

### Two notes

**Tags are highlighted too.** `BoardContext.jsx` searches over tags as well as the title, so if you search for a tag name the board filters but nothing gets marked. Including tags keeps that consistent.

**The search term gets escaped.** Building the regex straight from the input (like the snippet in the issue does) throws on special characters, so searching for `(` or `*` would crash the board. `escapeRegExp` prevents that.

Checked the split logic against special characters, mixed casing, an empty query and a missing title.

### Checklist
- [x] My code follows the project's style guidelines
- [x] I tested my changes locally (`npm run build` in `client` passes)
- [x] No README changes needed, setup and usage are unchanged
- [x] Commit message follows conventional commits