### PR TITLE
fix: show friendly UI message when API rate limit is hit (fixes #425)

### DIFF
--- a/devboard/client/src/context/BoardContext.jsx
+++ b/devboard/client/src/context/BoardContext.jsx
@@ -99,6 +99,11 @@ export const BoardProvider = ({ children }) => {
       setAllTasks((prev) => [...prev, data]);
     } catch (err) {
       console.error("addTask failed", err);
+      if (err.response?.status === 429) {
+        setError('Too many requests — slow down a bit! 🚦');
+      } else {
+        setError('Failed to add task. Try again!');
+      }
       throw err;
     }
   };
@@ -206,7 +211,8 @@ export const BoardProvider = ({ children }) => {
         login,
         logout,
         fetchTasks,
-        error
+        error,
+        setError
       }}
     >
       {children}


### PR DESCRIPTION
This PR adds error handling in BoardContext.jsx to catch HTTP 429 status codes and display a friendly rate-limit message to the user, as requested
Fixes #425