### PR TITLE
feat: add subtle dot grid pattern to board background

### DIFF
--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -198,7 +198,7 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFi
       )}
 
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="board flex flex-col md:flex-row gap-4 p-4 overflow-x-hidden md:overflow-x-auto overflow-y-auto h-full">
+        <div className="board board-bg flex flex-col md:flex-row gap-4 p-4 overflow-x-hidden md:overflow-x-auto overflow-y-auto h-full">
           {isEmpty ? (
             <div className="flex flex-col items-center justify-center w-full h-64 text-gray-500">
               <span className="text-4xl mb-4">🔍</span>

--- a/devboard/client/src/index.css
+++ b/devboard/client/src/index.css
@@ -25,6 +25,16 @@ body {
 ::-webkit-scrollbar-track { background: var(--bg-card); }
 ::-webkit-scrollbar-thumb { background: #333; border-radius: 3px; }
 
+.board-bg {
+  background-color: #0f0f10;
+  background-image: radial-gradient(
+    circle,
+    #2a2a2f 1px,
+    transparent 1px
+  );
+  background-size: 24px 24px;
+}
+
 @media print {
   .no-print {
     display: none !important;


### PR DESCRIPTION
## What & why

The Kanban board area was a flat `#0f0f10` fill, which looked empty and
unfinished, especially when a column or the whole board is empty. This adds
a subtle dot grid pattern (à la Notion / Linear) to give the surface some
texture without drawing attention away from the cards.

Closes #426 

## Changes

- **`client/src/index.css`**: new `.board-bg` utility: keeps the existing
  `#0f0f10` background colour and layers a `radial-gradient` dot grid on top
  (`#2a2a2f` dots, `24px` tile).
- **`client/src/components/Board/KanbanBoard.jsx`**: add the `board-bg`
  class to the `.board` container so the pattern spans the full board area,
  including the empty state.

~6 lines across 2 files. No backend or dependency changes.

## Testing

- Ran `npm run dev` and confirmed the pattern renders on the board, behind
  columns/cards and in the empty-board state.
- Verified the new rule loads and parses correctly (colour, gradient,
  `background-size: 24px 24px`); no existing rule sets a background on
  `.board`, so nothing is overridden.

## PR Checklist

- [x] My code follows the project style
- [x] I tested my changes locally
- [x] I updated the README if needed (no changes needed)
- [x] My commit messages are clear