### PR TITLE
feat: add pin button to keep important tasks at top

### DIFF
--- a/devboard/client/src/components/Board/Column.jsx
+++ b/devboard/client/src/components/Board/Column.jsx
@@ -30,8 +30,39 @@ const Column = ({
   isActive,
 }) => {
   const [sorted, setSorted] = useState(false);
+  const [pinnedIds, setPinnedIds] = useState(() => {
+    try {
+      return new Set(
+        tasks
+          .filter((task) => localStorage.getItem(`pin_${task._id}`) === "true")
+          .map((task) => task._id)
+      );
+    } catch {
+      return new Set();
+    }
+  });
   const [animate, setAnimate] = useState(false);
   const [collapsed, setCollapsed] = useState(() => readCollapsed(columnId));
+  const handlePin = (id) => {
+    setPinnedIds((prev) => {
+      const next = new Set(prev);
+      const nowPinned = !next.has(id);
+
+      if (nowPinned) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+
+      try {
+        localStorage.setItem(`pin_${id}`, String(nowPinned));
+      } catch {
+        // Not being able to remember the pin is not worth breaking the board over.
+      }
+
+      return next;
+    });
+  };
 
   useEffect(() => {
     try {
@@ -49,13 +80,18 @@ const Column = ({
     return () => clearTimeout(timeout);
   }, [tasks.length]);
 
-  const displayTasks = sorted
+  const displayTasks = (sorted
     ? [...tasks].sort((a, b) => {
       const order = { high: 0, medium: 1, low: 2 };
 
       return (order[a.priority] ?? 3) - (order[b.priority] ?? 3);
     })
-    : tasks;
+    : [...tasks]
+  ).sort(
+    (a, b) =>
+      (pinnedIds.has(b._id) ? 1 : 0) -
+      (pinnedIds.has(a._id) ? 1 : 0)
+  );
 
   const config =
     COLUMN_CONFIG[columnId] || {
@@ -134,6 +170,8 @@ const Column = ({
                   task={task}
                   index={index}
                   onSelect={onSelectTask}
+                  pinned={pinnedIds.has(task._id)}
+                  onPin={handlePin}
                 />
               ))
             )}

--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -66,7 +66,7 @@ const timeAgo = (date) => {
   return `${days}d ago`;
 };
 
-const TaskCard = ({ task, index, onSelect }) => {
+const TaskCard = ({ task, index, onSelect, pinned, onPin }) => {
   const [expanded, setExpanded] = useState(false);
   const [selectedSnippet, setSelectedSnippet] = useState(0);
   const [copied, setCopied] = useState(false);
@@ -178,6 +178,19 @@ const TaskCard = ({ task, index, onSelect }) => {
               className="shrink-0 text-xs"
             >
               {copied ? "✅" : "📋"}
+            </button>
+
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onPin(task._id);
+              }}
+              aria-label={pinned ? "Unpin task" : "Pin task"}
+              title={pinned ? "Unpin task" : "Pin task"}
+              className="shrink-0 text-xs"
+            >
+              {pinned ? "📌" : "📍"}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

Closes #407

Adds a pin 📌 toggle to task cards so users can keep important tasks visible at the top of their column.

## Changes

- **`TaskCard.jsx`** — Added `pinned` and `onPin` props with a 📌/📍 toggle button next to the copy button.
- **`Column.jsx`** — Added pinned task state and sorting logic to keep pinned tasks at the top.
- Pin state is persisted using `localStorage`.
- Pinned tasks remain at the top even when priority sorting is enabled.
- No backend or database changes are required.

## How It Works

- Click the 📌 button on a task to pin it.
- The pinned task immediately moves to the top of its column.
- Click the button again to unpin the task.
- Pin state persists after refreshing the page.

## Testing

- Open the board.
- Pin a task using the 📌 button.
- Verify that it moves to the top of the column.
- Refresh the page and verify that it remains pinned.
- Unpin the task and verify that it returns to its normal position.

## Notes

- Pin state is stored using the `pin_<task._id>` localStorage key.
- The implementation follows the existing localStorage pattern in `Column.jsx`.
- Pinning is handled entirely on the frontend; no backend changes were made.