### PR TITLE
fix: remove duplicate copy button and assignee avatar from task card

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -377,34 +377,19 @@ const TaskCard = ({ task, index, onSelect, pinned, onPin }) => {
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  navigator.clipboard.writeText(task.title);
+                  onSelect(task);
                 }}
-                title="Copy title"
-                className="opacity-0 group-hover:opacity-100 text-[#555] hover:text-[#aaa] transition text-xs"
+                className="opacity-0 group-hover:opacity-100 text-[10px] px-2 py-1 rounded bg-gray-600 text-white hover:bg-gray-700 transition-opacity"
               >
-                📋
+                ✏️
               </button>
+
               {task.assignee?.name && (
                 <div title={task.assignee.name} className="w-5 h-5 rounded-full bg-purple-700 flex items-center justify-center text-[9px] font-bold text-white">
                   {task.assignee.name[0].toUpperCase()}
                 </div>
               )}
             </div>
-            <button
-              onClick={(e) => {
-              e.stopPropagation();
-              onSelect(task);
-            }}
-             className="opacity-0 group-hover:opacity-100 text-[10px] px-2 py-1 rounded bg-gray-600 text-white hover:bg-gray-700 transition-opacity"
-             >
-              ✏️
-             </button>
-
-            {task.assignee?.name && (
-              <div title={task.assignee.name} className="w-5 h-5 rounded-full bg-purple-700 flex items-center justify-center text-[9px] font-bold text-white">
-                {task.assignee.name[0].toUpperCase()}
-              </div>
-            )}
           </div>
 
           {/* Last updated */}


### PR DESCRIPTION
Closes #430

### What

The task card rendered two identical "Copy title" buttons: one in the header next to the title and one in the card footer. Both ran `navigator.clipboard.writeText(task.title)`, so the footer one was pure duplication. The assignee avatar was rendered twice for the same reason.

This removes the footer copy button and the duplicated avatar, and groups the edit button together with the remaining avatar.

### Why

The header button is the one that gives visual feedback (📋 → ✅), so it is the one worth keeping. Removing the duplicates also fixes the footer layout: the `justify-between` container had four children instead of two, which pushed the edit button and avatar apart in a way that was clearly unintended.

### Testing

Ran the app locally (client + server + MongoDB), verified on the board that each card now shows exactly one 📋 button in the header and exactly one assignee avatar, that copying still works with the ✅ confirmation, and that the ✏️ edit button still opens the task modal.
