### PR TITLE
fix: wrap long task titles instead of stretching the card

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -166,7 +166,7 @@ const TaskCard = ({ task, index, onSelect, pinned, onPin }) => {
         >
           {/* Title */}
           <div className="flex items-start justify-between gap-2 mb-2">
-            <p className="text-sm font-medium text-[#f0f0f0] leading-snug">
+            <p className="text-sm font-medium text-[#f0f0f0] leading-snug min-w-0 break-words">
               {highlightMatch(task.title, searchQuery)}
             </p>
 


### PR DESCRIPTION
Closes #431

### What

Adds `min-w-0 break-words` to the task title in `TaskCard.jsx`.

### Why

A long title with no spaces (and no hyphens — the browser already breaks at hyphens) could not wrap, so the title element kept growing and stretched the card far past its column, pushing the rest of the board sideways. As a flex child, the `<p>` also refused to shrink below its content width, which is what `min-w-0` addresses; `break-words` then lets the unbroken word wrap inside the card.

### Testing

Ran the app locally and created a task with a long single-word title. Before the change the card stretched across the board; after it, the title wraps and the card stays inside its column (title 142px in a 214px card, 222px column). Normal titles are unchanged.
