### PR TITLE
fix: label the task card edit button for screen readers

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -375,10 +375,13 @@ const TaskCard = ({ task, index, onSelect, pinned, onPin }) => {
             </div>
             <div className="flex items-center gap-2">
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onSelect(task);
                 }}
+                aria-label="Edit task"
+                title="Edit task"
                 className="opacity-0 group-hover:opacity-100 text-[10px] px-2 py-1 rounded bg-gray-600 text-white hover:bg-gray-700 transition-opacity"
               >
                 ✏️


### PR DESCRIPTION
## What

Gives the ✏️ edit button in the task card footer an `aria-label` and a `title`.

## Why

The button had neither, so its accessible name fell back to its own content — the ✏️ emoji — and a screen reader announced it as "pencil, button" instead of describing the action. Sighted users got no tooltip either, and since the button only fades in on hover there was nothing else to go by.

The copy and pin buttons next to the title already follow this pattern, so this just brings the third button in line with its siblings. It also picks up the explicit `type="button"` those two carry.

## Testing

Ran the board locally with several tasks and inspected the rendered button: its accessible name is now "Edit task" rather than the emoji, the tooltip appears on hover, and clicking it still opens the edit modal as before. No console errors.

Closes #450