### PR TITLE
fix: give each assignee avatar its own color

### DIFF
--- a/devboard/client/src/components/Board/TaskCard.jsx
+++ b/devboard/client/src/components/Board/TaskCard.jsx
@@ -29,6 +29,22 @@ const TAG_COLORS = [
 const getTagColor = (tag) =>
   TAG_COLORS[tag.charCodeAt(0) % TAG_COLORS.length];
 
+const AVATAR_COLORS = [
+  "bg-purple-700",
+  "bg-blue-600",
+  "bg-green-600",
+  "bg-rose-600",
+  "bg-amber-600",
+  "bg-teal-600",
+];
+
+// Sum every character so that names sharing a first letter still differ.
+const getAvatarColor = (name) => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash += name.charCodeAt(i);
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+};
+
 // Search terms are raw user input, so they have to be escaped before they can
 // be used as a pattern — searching for "(" would otherwise throw.
 const escapeRegExp = (text) => text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -385,7 +401,7 @@ const TaskCard = ({ task, index, onSelect, pinned, onPin }) => {
               </button>
 
               {task.assignee?.name && (
-                <div title={task.assignee.name} className="w-5 h-5 rounded-full bg-purple-700 flex items-center justify-center text-[9px] font-bold text-white">
+                <div title={task.assignee.name} className={`w-5 h-5 rounded-full ${getAvatarColor(task.assignee.name)} flex items-center justify-center text-[9px] font-bold text-white`}>
                   {task.assignee.name[0].toUpperCase()}
                 </div>
               )}


### PR DESCRIPTION
## What

Derives the assignee avatar colour from the assignee's name instead of hardcoding `bg-purple-700`.

Adds an `AVATAR_COLORS` palette and a `getAvatarColor(name)` helper next to the existing `getTagColor`, in the same style.

## Why

Every avatar circle was the same purple, so on a board with several assignees the badges were indistinguishable and the colour carried no information.

One deviation from the suggestion in the issue: the hash sums **every** character of the name rather than using `charCodeAt(0)`. With only the first character, any two names sharing a first letter — Bea and Ben, Anna and Alex — still collide, which is the common case on a small team and exactly what the issue is about. Summing the whole string costs one extra line and avoids that.

Frontend only, no backend changes. With a fixed palette collisions are still possible for enough distinct names; the goal here is distinguishability, not uniqueness.

## Testing

Ran the board locally with six assignees chosen to cover the whole palette — Bea, Ben, Vera, Amir, Anna, Maja — and each avatar rendered a different colour. Bea and Ben share a first letter and still come out purple vs. blue, which is the case the wider hash is for. No console errors.

Closes #109