### PR TITLE
feat(board): add focus mode toggle to hide done tasks (#471)

### DIFF
--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -8,7 +8,7 @@ import confetti from "canvas-confetti";
 const COLUMNS = ["backlog", "inprogress", "review", "done"];
 
 
-const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFilter = "all" }) => {
+const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFilter = "all", focusMode = false }) => {
 
   const { tasks, updateTask, addTask, loading } = useBoard();
   const displayedTasks = filteredTasks ?? tasks;
@@ -50,7 +50,11 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFi
 
   
 
-  const isEmpty = COLUMNS.every(col => getTasksByStatus(col).length === 0);
+  const visibleColumns = focusMode
+    ? columns.filter((col) => col.toLowerCase() !== "done")
+    : columns;
+
+  const isEmpty = visibleColumns.every(col => getTasksByStatus(col).length === 0);
   const totalTasks = tasks.length;
   const playDoneSound = () => {
     const AudioContextClass =
@@ -253,14 +257,14 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFi
             </div>
           ) : (
             <>
-              {columns.map((col) => (
+              {visibleColumns.map((col) => (
                 <Column
                   key={col}
                   columnId={col}
                   tasks={getTasksByStatus(col)}
                   onSelectTask={onSelectTask}
                   onAddTask={handleAddTask}
-                  isActive={columns.indexOf(col) === activeCol}
+                  isActive={visibleColumns.indexOf(col) === activeCol}
                 />
               ))}
               <button

--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -31,6 +31,7 @@ const Dashboard = () => {
   useEffect(() => {
     document.title = "Dashboard — DevBoard";
   }, []);
+  const [focusMode, setFocusMode] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [selectedTask, setSelectedTask] = useState(null);
   const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
@@ -240,6 +241,18 @@ const Dashboard = () => {
             👋 {getGreeting()},{user?.name}
           </span> */}
           <button
+            type="button"
+            onClick={() => setFocusMode((v) => !v)}
+            aria-label={focusMode ? "Disable focus mode" : "Enable focus mode"}
+            className={`text-xs px-3 py-1.5 rounded-lg border transition ${
+              focusMode
+                ? "border-purple-500 text-purple-400 bg-purple-500/10"
+                : "border-[#2a2a2f] text-[#666] hover:text-white"
+            }`}
+          >
+            {focusMode ? "🎯 Focused" : "🎯 Focus"}
+          </button>
+          <button
             onClick={handleClearDone}
             className="text-xs text-[#666] hover:text-red-400 transition px-3 py-1.5 border border-[#2a2a2f] rounded-lg"
           >
@@ -303,7 +316,7 @@ const Dashboard = () => {
             </button>
           </div>
         ) : (
-          <KanbanBoard onSelectTask={setSelectedTask} />
+          <KanbanBoard onSelectTask={setSelectedTask} focusMode={focusMode} />
         )}
       </div>
       {/* Task Edit Modal */}


### PR DESCRIPTION
Fixes #471

### Summary
Adds a Focus Mode toggle in the navbar to optionally hide the **Done** column on the Kanban board so users can concentrate on pending work without visual clutter.

### Changes
- Added \ocusMode\ toggle state and button (\🎯 Focus\ / \🎯 Focused\) in \Dashboard.jsx\ navbar.
- Passed \ocusMode\ prop to \KanbanBoard.jsx\ to filter out the \done\ column when enabled.
- Updated \isEmpty\ calculation to adapt to visible columns.