### PR TITLE
fix: keep column badges behind modal overlay

### DIFF
--- a/devboard/client/src/components/Board/KanbanBoard.jsx
+++ b/devboard/client/src/components/Board/KanbanBoard.jsx
@@ -191,7 +191,7 @@ const KanbanBoard = ({ tasks: filteredTasks, onSelectTask, activeCol, priorityFi
     <>
       {showinput && (
         <div
-          className="fixed inset-0 bg-black/90 backdrop-blur-sm flex items-center justify-center"
+          className="fixed inset-0 bg-black/90 backdrop-blur-sm flex items-center justify-center z-50"
           onClick={handleCancel}
           onKeyDown={(e) => {
             if (e.key === 'Escape') handleCancel();


### PR DESCRIPTION
## Summary

* Add the correct z-index to the Add Column modal backdrop
* Keep column task count badges behind the modal overlay

## Testing

* Opened the Add Column modal with populated columns
* Verified that task count badges no longer appear above the backdrop
* Verified the production build with `npm run build`

Closes #500
