### PR TITLE
feat: display last 3 recently viewed tasks in navbar

### DIFF
--- a/devboard/client/src/pages/Dashboard.jsx
+++ b/devboard/client/src/pages/Dashboard.jsx
@@ -32,25 +32,45 @@ const Dashboard = () => {
     activeTag,
     setActiveTag,
   } = useBoard();
+
   const { stars, loading: starsLoading } = useGithubStars();
+
   useEffect(() => {
     document.title = "Dashboard — DevBoard";
   }, []);
+
   const [focusMode, setFocusMode] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [selectedTask, setSelectedTask] = useState(null);
-  const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
-  const [showTop, setShowTop] = useState(false);
-  const [isFullscreen, setIsFullscreen] = useState(false);
-  const [isNight, setIsNight] = useState(isNightTime());
-  const [searchHistory, setSearchHistory] = useState(() => {
+
+  // Recently viewed tasks
+  const [recentTasks, setRecentTasks] = useState(() => {
     try {
-      const saved = JSON.parse(localStorage.getItem("search_history") || "[]");
+      const saved = JSON.parse(
+        localStorage.getItem("recent_tasks") || "[]"
+      );
       return Array.isArray(saved) ? saved : [];
     } catch {
       return [];
     }
   });
+
+  const [isCreatingFirstTask, setIsCreatingFirstTask] = useState(false);
+  const [showTop, setShowTop] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isNight, setIsNight] = useState(isNightTime());
+
+  const [searchHistory, setSearchHistory] = useState(() => {
+    try {
+      const saved = JSON.parse(
+        localStorage.getItem("search_history") || "[]"
+      );
+      return Array.isArray(saved) ? saved : [];
+    } catch {
+      return [];
+    }
+  });
+
   useEffect(() => {
     const interval = setInterval(() => {
       setIsNight(isNightTime());
@@ -58,22 +78,29 @@ const Dashboard = () => {
 
     return () => clearInterval(interval);
   }, []);
+
   useEffect(() => {
     document.documentElement.classList.toggle("light", !isNight);
   }, [isNight]);
+
   useEffect(() => {
     const handleScroll = (event) => {
       let scrollTop = 0;
+
       if (event.target === document || event.target === window) {
         scrollTop = window.scrollY;
       } else if (event.target) {
         scrollTop = event.target.scrollTop;
       }
+
       setShowTop(scrollTop > 300);
     };
 
     window.addEventListener("scroll", handleScroll, true);
-    return () => window.removeEventListener("scroll", handleScroll, true);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll, true);
+    };
   }, []);
 
   useEffect(() => {
@@ -82,8 +109,12 @@ const Dashboard = () => {
     };
 
     document.addEventListener("fullscreenchange", handleFullscreenChange);
+
     return () =>
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      document.removeEventListener(
+        "fullscreenchange",
+        handleFullscreenChange
+      );
   }, []);
 
   const handleFullscreen = async () => {
@@ -96,6 +127,31 @@ const Dashboard = () => {
     } catch (error) {
       console.warn("Unable to toggle fullscreen mode:", error);
     }
+  };
+
+  // Save and select a recently viewed task.
+  const handleSelectTask = (task) => {
+    if (!task) return;
+
+    let recent = [];
+
+    try {
+      const saved = JSON.parse(
+        localStorage.getItem("recent_tasks") || "[]"
+      );
+      recent = Array.isArray(saved) ? saved : [];
+    } catch {
+      recent = [];
+    }
+
+    const updated = [
+      task,
+      ...recent.filter((t) => t?._id !== task._id),
+    ].slice(0, 3);
+
+    setRecentTasks(updated);
+    localStorage.setItem("recent_tasks", JSON.stringify(updated));
+    setSelectedTask(task);
   };
 
   if (loading) {
@@ -134,7 +190,10 @@ const Dashboard = () => {
   const handleClearDone = async () => {
     if (window.confirm("Clear all done tasks?")) {
       const doneTasks = tasks.filter((t) => t.status === "done");
-      await Promise.all(doneTasks.map((t) => deleteTask(t._id)));
+
+      await Promise.all(
+        doneTasks.map((t) => deleteTask(t._id))
+      );
     }
   };
 
@@ -148,13 +207,18 @@ const Dashboard = () => {
 
   const handleSearch = (query) => {
     setSearchQuery(query);
+
     const trimmed = query.trim();
+
     if (!trimmed) return;
 
     const updated = [
       trimmed,
-      ...searchHistory.filter((h) => h.toLowerCase() !== trimmed.toLowerCase()),
+      ...searchHistory.filter(
+        (h) => h.toLowerCase() !== trimmed.toLowerCase()
+      ),
     ].slice(0, 5);
+
     setSearchHistory(updated);
     localStorage.setItem("search_history", JSON.stringify(updated));
   };
@@ -177,15 +241,43 @@ const Dashboard = () => {
       <div className="flex flex-col gap-3 px-5 py-3 bg-[var(--bg-card)] border-b border-[var(--border-primary)] md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-2 shrink-0">
           <span className="text-lg">🗂️</span>
+
           <span className="font-semibold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
             DevBoard
           </span>
+
           <span className="text-xs bg-purple-600/20 text-purple-400 px-2 py-0.5 rounded-full ml-1">
             beta
           </span>
+
           <span className="text-xs text-[var(--text-secondary)] ml-2">
             {tasks.length} {tasks.length === 1 ? "task" : "tasks"}
           </span>
+
+          {/* Recently viewed tasks */}
+          {recentTasks.length > 0 && (
+            <div className="flex items-center gap-1.5 ml-2 overflow-hidden">
+              <span
+                className="text-xs text-[var(--text-muted)] shrink-0"
+                title="Recently viewed tasks"
+              >
+                🕐
+              </span>
+
+              {recentTasks.map((task) => (
+                <button
+                  key={task._id}
+                  type="button"
+                  onClick={() => handleSelectTask(task)}
+                  title={task.title}
+                  className="text-xs bg-[var(--bg-muted)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-purple-500/10 border border-[var(--border-primary)] px-2 py-1 rounded-full max-w-[140px] truncate transition"
+                >
+                  {task.title}
+                </button>
+              ))}
+            </div>
+          )}
+
           {activeTag && (
             <button
               onClick={() => setActiveTag(null)}
@@ -195,6 +287,7 @@ const Dashboard = () => {
             </button>
           )}
         </div>
+
         <div className="flex-1 w-full max-w-xl md:px-6 no-print">
           <label className="relative block">
             <input
@@ -202,13 +295,16 @@ const Dashboard = () => {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") handleSearch(searchQuery);
+                if (e.key === "Enter") {
+                  handleSearch(searchQuery);
+                }
               }}
               onBlur={() => handleSearch(searchQuery)}
               placeholder="Search tasks by title or tag..."
               className="w-full bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded-xl px-4 py-2.5 text-sm text-[var(--text-primary)] placeholder-[var(--text-muted)] focus:outline-none focus:border-purple-500 focus:ring-2 focus:ring-purple-500/15 transition"
             />
           </label>
+
           {searchHistory.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mt-2">
               {searchHistory.map((h) => (
@@ -224,7 +320,16 @@ const Dashboard = () => {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-3 no-print"><button type="button" onClick={handlePrint} className="text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg">🖨️ Print</button>
+
+        <div className="flex items-center gap-3 no-print">
+          <button
+            type="button"
+            onClick={handlePrint}
+            className="text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg"
+          >
+            🖨️ Print
+          </button>
+
           <a
             href="https://github.com/anoopcodehack/DevBoard"
             target="_blank"
@@ -235,30 +340,42 @@ const Dashboard = () => {
               ? `⭐ ${formatStars(stars)} Star on GitHub`
               : "⭐ Star on GitHub"}
           </a>
-          <span className="text-xs text-[var(--text-secondary)]">👋 {user?.name}</span>
+
+          <span className="text-xs text-[var(--text-secondary)]">
+            👋 {user?.name}
+          </span>
+
           {document.fullscreenEnabled && (
             <button
               onClick={handleFullscreen}
-              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-              className="text-xs text-[var(--text-secondary)] hover:text-red-400 transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg"
+              aria-label={
+                isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
+              }
+              className="text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg"
             >
               {isFullscreen ? "⊠ Exit" : "⛶ Focus"}
             </button>
           )}
+
           {/* <span className="text-xs text-[var(--text-secondary)]">
             👋 {getGreeting()},{user?.name}
           </span> */}
+
           <button
             type="button"
             onClick={() => setFocusMode((v) => !v)}
-            aria-label={focusMode ? "Disable focus mode" : "Enable focus mode"}
-            className={`text-xs px-3 py-1.5 rounded-lg border transition ${focusMode
+            aria-label={
+              focusMode ? "Disable focus mode" : "Enable focus mode"
+            }
+            className={`text-xs px-3 py-1.5 rounded-lg border transition ${
+              focusMode
                 ? "border-purple-500 text-purple-400 bg-purple-500/10"
                 : "border-[var(--border-primary)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-              }`}
+            }`}
           >
             {focusMode ? "🎯 Focused" : "🎯 Focus"}
           </button>
+
           <button
             onClick={handleClearDone}
             className="text-xs text-[var(--text-secondary)] hover:text-red-400 transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg"
@@ -281,9 +398,11 @@ const Dashboard = () => {
           >
             ⌨️ ?
           </button>
+
           <span className="text-xs text-[var(--text-secondary)]">
             {isNight ? "🌙 Night mode" : "☀️ Day mode"}
           </span>
+
           <button
             onClick={handleLogout}
             className="text-xs text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition px-3 py-1.5 border border-[var(--border-primary)] rounded-lg"
@@ -305,18 +424,22 @@ const Dashboard = () => {
           onSessionComplete={handleSessionComplete}
         />
       </div>
+
       {/* Kanban Board */}
       <div className="flex-1 overflow-hidden">
         {tasks.length === 0 ? (
           <div className="flex-1 h-full flex flex-col items-center justify-center text-center p-8">
             <span className="text-6xl mb-4">👋</span>
+
             <h2 className="text-2xl font-semibold text-[var(--text-primary)] mb-2">
               Welcome to your board!
             </h2>
+
             <p className="text-[var(--text-tertiary)] mb-6 max-w-md">
               You don't have any tasks yet. Click + Add card to create your
               first one.
             </p>
+
             <button
               onClick={() => setIsCreatingFirstTask(true)}
               className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2.5 rounded-lg font-medium transition"
@@ -325,9 +448,13 @@ const Dashboard = () => {
             </button>
           </div>
         ) : (
-          <KanbanBoard onSelectTask={setSelectedTask} focusMode={focusMode} />
+          <KanbanBoard
+            onSelectTask={handleSelectTask}
+            focusMode={focusMode}
+          />
         )}
       </div>
+
       {/* Task Edit Modal */}
       {selectedTask && (
         <TaskModal
@@ -341,6 +468,7 @@ const Dashboard = () => {
           updateTask={updateTask}
         />
       )}
+
       {/* Create First Task Modal */}
       {isCreatingFirstTask && (
         <TaskModal
@@ -353,15 +481,22 @@ const Dashboard = () => {
           }}
         />
       )}
+
+      {/* Scroll To Top Button */}
       {showTop && (
         <button
           onClick={() => {
             window.scrollTo({ top: 0, behavior: "smooth" });
+
             const scrollContainers = document.querySelectorAll(
-              ".overflow-y-auto, .overflow-y-scroll",
+              ".overflow-y-auto, .overflow-y-scroll"
             );
+
             scrollContainers.forEach((container) => {
-              container.scrollTo({ top: 0, behavior: "smooth" });
+              container.scrollTo({
+                top: 0,
+                behavior: "smooth",
+              });
             });
           }}
           className="no-print fixed bottom-6 right-6 bg-purple-600 hover:bg-purple-500 text-white rounded-full w-10 h-10 text-lg shadow-lg transition z-50 flex items-center justify-center"
@@ -370,11 +505,15 @@ const Dashboard = () => {
           ⬆️
         </button>
       )}
+
+      {/* Help Modal */}
       {showHelp && (
         <div
           className="fixed inset-0 bg-black/90 backdrop-blur-sm flex items-center justify-center z-50 p-4"
           onClick={(e) => {
-            if (e.target === e.currentTarget) setShowHelp(false);
+            if (e.target === e.currentTarget) {
+              setShowHelp(false);
+            }
           }}
         >
           <div className="bg-[var(--bg-card)] border border-[var(--border-primary)] rounded-xl w-full max-w-sm shadow-2xl">
@@ -382,6 +521,7 @@ const Dashboard = () => {
               <h2 className="font-semibold text-[var(--text-primary)] text-sm">
                 Keyboard Shortcuts
               </h2>
+
               <button
                 onClick={() => setShowHelp(false)}
                 className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-xl leading-none"
@@ -390,21 +530,33 @@ const Dashboard = () => {
                 ✕
               </button>
             </div>
+
             <div className="p-5 flex flex-col gap-3 text-sm">
               <div className="flex items-center justify-between">
-                <span className="text-[var(--text-tertiary)]">New task</span>
+                <span className="text-[var(--text-tertiary)]">
+                  New task
+                </span>
+
                 <kbd className="bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded px-1.5 py-0.5 font-mono text-xs text-[var(--text-primary)]">
                   N
                 </kbd>
               </div>
+
               <div className="flex items-center justify-between">
-                <span className="text-[var(--text-tertiary)]">Close modal</span>
+                <span className="text-[var(--text-tertiary)]">
+                  Close modal
+                </span>
+
                 <kbd className="bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded px-1.5 py-0.5 font-mono text-xs text-[var(--text-primary)]">
                   ESC
                 </kbd>
               </div>
+
               <div className="flex items-center justify-between">
-                <span className="text-[var(--text-tertiary)]">Toggle this menu</span>
+                <span className="text-[var(--text-tertiary)]">
+                  Toggle this menu
+                </span>
+
                 <kbd className="bg-[var(--bg-primary)] border border-[var(--border-primary)] rounded px-1.5 py-0.5 font-mono text-xs text-[var(--text-primary)]">
                   ?
                 </kbd>
@@ -416,4 +568,5 @@ const Dashboard = () => {
     </div>
   );
 };
+
 export default Dashboard;


### PR DESCRIPTION
## Description

Closes #337

Implemented support for displaying the 3 most recently viewed tasks in the navbar.

### Changes
- Store recently viewed tasks in localStorage
- Keep only the 3 most recently viewed tasks
- Remove duplicate tasks when viewed again
- Display recent tasks as clickable navbar chips
- Clicking a recent task opens/selects that task
- Persist recent tasks across page refreshes

### Testing
- Verified recent tasks are saved to localStorage
- Verified the list is limited to 3 tasks
- Verified duplicate tasks are reordered correctly
- Verified recent task chips are clickable
- Verified the client build succeeds without errors