### PR TITLE
docs: add keyboard shortcuts section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ DevBoard is a task board made for how developers actually work — track issues,
 --
 <img width="893" height="608" alt="Screenshot 2026-06-06 095817" src="https://github.com/user-attachments/assets/a3ee8e4e-026b-4f8f-be2e-d0a2f436810c" />
 <img width="893" height="608" alt="DevBoard screenshot" src="./docs/screenshot.png" />
+
+---
+
+## ⌨️ Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `N` | Create a new task |
+| `Esc` | Close the open modal |
+
+> `N` is disabled while typing in an input or textarea, so it won't interrupt you mid-sentence.
+
 ---
  
 ## 🛠️ Tech Stack


### PR DESCRIPTION
Closes #503

Added a Keyboard Shortcuts section documenting the two shortcuts I found by searching the codebase:
- N: opens the new task modal (disabled while typing in an input/textarea)
- Esc: closes the open modal

Verified both directly in KanbanBoard.jsx and TaskModal.jsx.